### PR TITLE
DPP-827 - Refund missing learners

### DIFF
--- a/src/calculator/SFA.DAS.Payments.Calc.CoInvestedPayments/CoInvestedPaymentsProcessor.cs
+++ b/src/calculator/SFA.DAS.Payments.Calc.CoInvestedPayments/CoInvestedPaymentsProcessor.cs
@@ -220,9 +220,9 @@ namespace SFA.DAS.Payments.Calc.CoInvestedPayments
                 throw new CoInvestedPaymentsProcessorException(CoInvestedPaymentsProcessorException.ErrorReadingPaymentsHistoryMessage, historyPayments.Exception);
             }
 
-            AddRefundPayment(payments,historyPayments.Items, FundingSource.FullyFundedSfa, paymentDue, currentPeriod);
-            AddRefundPayment(payments,historyPayments.Items, FundingSource.CoInvestedSfa, paymentDue, currentPeriod);
-            AddRefundPayment(payments,historyPayments.Items, FundingSource.CoInvestedEmployer, paymentDue, currentPeriod);
+            AddRefundPayment(payments, historyPayments.Items, FundingSource.FullyFundedSfa, paymentDue, currentPeriod);
+            AddRefundPayment(payments, historyPayments.Items, FundingSource.CoInvestedSfa, paymentDue, currentPeriod);
+            AddRefundPayment(payments, historyPayments.Items, FundingSource.CoInvestedEmployer, paymentDue, currentPeriod);
         }
 
         private void AddRefundPayment(ICollection<Payment> payments,
@@ -231,8 +231,13 @@ namespace SFA.DAS.Payments.Calc.CoInvestedPayments
                                             PaymentDue paymentDue,
                                             CollectionPeriod currentPeriod)
         {
-            var amountPaidFromSource = historyPayments.Where(x => x.FundingSource == fundingSource).Sum(x => x.Amount);
             var amountPaidTotal = historyPayments.Sum(x => x.Amount);
+            if (amountPaidTotal == 0)
+            {
+                return;
+            }
+
+            var amountPaidFromSource = historyPayments.Where(x => x.FundingSource == fundingSource).Sum(x => x.Amount);
 
             var percentagePaidFromSource = amountPaidFromSource / amountPaidTotal;
             var amountToRefund = paymentDue.AmountDue * percentagePaidFromSource;

--- a/src/calculator/SFA.DAS.ProviderPayments.Calc.LevyPayments/LevyPaymentsProcessor.cs
+++ b/src/calculator/SFA.DAS.ProviderPayments.Calc.LevyPayments/LevyPaymentsProcessor.cs
@@ -211,6 +211,11 @@ namespace SFA.DAS.ProviderPayments.Calc.LevyPayments
 
             var historyPayments = historyPaymentsResponse.Items;
             var totalAmountPaidInPeriod = historyPayments.Sum(x => x.Amount);
+            if (totalAmountPaidInPeriod == 0)
+            {
+                return 0m;
+            }
+
             var totalLevyPaidInPeriod = historyPayments.Where(x => x.FundingSource == FundingSource.Levy).Sum(x => x.Amount);
             var percentagePaidByLevyInPeriod = totalLevyPaidInPeriod / totalAmountPaidInPeriod;
 


### PR DESCRIPTION
Fix divide by zero error when refund payments are all levy of co-fund