### PR TITLE
Excluded reference commitments which were ended on the same day

### DIFF
--- a/src/AcceptanceTesting/Features/datalock_errors.feature
+++ b/src/AcceptanceTesting/Features/datalock_errors.feature
@@ -304,6 +304,21 @@ Scenario: DLOCK08 - When multiple matching record found in an employer digital a
         | 2-450-1-01/05/2017       | 74-002             | 01/05/2017 | 450            | 2              | 1            | 10000            | 01/05/2017     |
 
 
+Scenario: DLOCK08(a) - When multiple valid matching commitments found in an employer digital account then datalock DLOCK_08 will not be produced
+
+    Given the apprenticeship funding band maximum for each learner is 17000
+    And levy balance > agreed price for all months
+	And the following commitments exist:
+        | commitment Id | version Id | Provider   | ULN       | framework code | programme type | pathway code | agreed price | start date | end date   | status    | effective from |
+        | 73            | 73-125     | Provider a | learner a | 450            | 2              | 1            | 10000        | 01/05/2017 | 01/05/2017 | cancelled | 01/05/2017     |
+        | 74            | 74-002     | Provider a | learner a | 450            | 2              | 1            | 10000        | 01/05/2017 | 08/08/2018 | active    | 01/05/2017     |
+    When an ILR file is submitted with the following data:  
+        | Provider   | ULN       | framework code | programme type | pathway code | start date | planned end date | completion status | Total training price | Total training price effective date |
+        | Provider a | learner a | 450            | 2              | 1            | 01/05/2017 | 08/08/2018       | continuing        | 10000                | 01/05/2017                          |
+	Then the following data lock event is returned:
+        | Price Episode identifier | Apprenticeship Id | ULN       | ILR Start Date | ILR Training Price |
+        | 2-450-1-01/05/2017       | 74                | learner a | 01/05/2017     | 10000              |
+    And no data lock event errors occurred
 
 Scenario: DLOCK07(a) - When price is changed, then effective to is set on previous price episode
     Given the following commitments exist:

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/DataLockSteps.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/DataLockSteps.cs
@@ -55,6 +55,13 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
             DataLockAssertions.AssertDataLockOutput(DataLockContext, SubmissionContext.SubmissionResults.ToArray());
         }
 
+        [Then(@"no data lock event errors occurred")]
+        public void ThenNoDataLockEventErorsOccured()
+        {
+            EnsureSubmissionsHaveHappened();
+            DataLockAssertions.AssertDataLockOutput(DataLockContext, SubmissionContext.SubmissionResults.ToArray());
+        }
+
         [Then(@"the data lock event has the following periods")]
         public void ThenTheDataLockEventHasTheFollowingPeriods(Table table)
         {

--- a/src/OpaEarning/Build/Deploy/1718/copy mappings/DasEarningsCopyToDedsMapping.xml
+++ b/src/OpaEarning/Build/Deploy/1718/copy mappings/DasEarningsCopyToDedsMapping.xml
@@ -2,11 +2,6 @@
 <CopyCatConfig>
   <SourceConnectionString>SourceConnectionString</SourceConnectionString>
   <DestinationConnectionString>DestinationConnectionString</DestinationConnectionString>
-  <SqlBulkCopySettings>
-    <BatchSize>2000</BatchSize>
-    <BulkCopyTimeout>7200</BulkCopyTimeout>
-    <EnableStreaming>true</EnableStreaming>
-  </SqlBulkCopySettings>
   <TableMappings>
     <TableMapping>
       <Source>[Rulebase].[vw_AEC_Cases]</Source>

--- a/src/SharedPipelineComponents/Datalock/Deploy/sql/dml/02 Ilr.DataLock.Populate.Reference.DasCommitments.dml.sql
+++ b/src/SharedPipelineComponents/Datalock/Deploy/sql/dml/02 Ilr.DataLock.Populate.Reference.DasCommitments.dml.sql
@@ -52,6 +52,7 @@ INSERT INTO [Reference].[DasCommitments]
     WHERE [ULN] IN (SELECT DISTINCT [ULN] 
 					FROM 
 					[Valid].[Learner] )
+	AND CONVERT(VARCHAR(12),[StartDate],103) <> CONVERT(VARCHAR(12),[EndDate],103)
     GROUP BY [CommitmentId],
         [Uln],
         [Ukprn],

--- a/src/SharedPipelineComponents/Datalock/DeployPeriodEnd/sql/dml/03 PeriodEnd.Populate.Reference.Commitments.dml.sql
+++ b/src/SharedPipelineComponents/Datalock/DeployPeriodEnd/sql/dml/03 PeriodEnd.Populate.Reference.Commitments.dml.sql
@@ -49,6 +49,7 @@ INSERT INTO [Reference].[DasCommitments]
         [EffectiveToDate],
         [LegalEntityName]
     FROM ${DAS_Commitments.FQ}.[dbo].[DasCommitments]
+	WHERE CONVERT(VARCHAR(12),[StartDate],103) <> CONVERT(VARCHAR(12),[EndDate],103)
     GROUP BY [CommitmentId],
         [Uln],
         [Ukprn],

--- a/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/SFA.DAS.CollectionEarnings.DataLock.IntegrationTests.csproj
+++ b/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/SFA.DAS.CollectionEarnings.DataLock.IntegrationTests.csproj
@@ -270,6 +270,9 @@
     <Content Include="Utilities\Sql\DPP-222\IlrAcceptanceCriteria1.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Utilities\Sql\IlrSubmissionDLock08Error.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Utilities\Sql\IncentiveEarningsRepository\PeriodEnd\IlrPeriodEndFirstIncentiveEarnings.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/Utilities/Sql/IlrSubmissionDLock08Error.sql
+++ b/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/Utilities/Sql/IlrSubmissionDLock08Error.sql
@@ -1,0 +1,19 @@
+﻿-- Learning provider
+INSERT [Valid].[LearningProvider] ([UKPRN]) VALUES (10007459)
+INSERT [Input].[LearningProvider] ([LearningProvider_Id], [UKPRN]) VALUES (1, 10007459)
+
+-- Learner
+INSERT [Valid].[Learner] ([LearnRefNumber], [PrevLearnRefNumber], [PrevUKPRN], [ULN], [FamilyName], [GivenNames], [DateOfBirth], [Ethnicity], [Sex], [LLDDHealthProb], [NINumber], [PriorAttain], [Accom], [ALSCost], [PlanLearnHours], [PlanEEPHours], [MathGrade], [EngGrade], [HomePostcode], [CurrentPostcode], [LrnFAM_DLA], [LrnFAM_ECF], [LrnFAM_EDF1], [LrnFAM_EDF2], [LrnFAM_EHC], [LrnFAM_FME], [LrnFAM_HNS], [LrnFAM_LDA], [LrnFAM_LSR1], [LrnFAM_LSR2], [LrnFAM_LSR3], [LrnFAM_LSR4], [LrnFAM_MCF], [LrnFAM_NLM1], [LrnFAM_NLM2], [LrnFAM_PPE1], [LrnFAM_PPE2], [LrnFAM_SEN], [ProvSpecMon_A], [ProvSpecMon_B]) 
+VALUES (N'1', NULL, NULL, 8628555861, N'FamilyName', N'GivenNames', CAST(N'1983-11-21' AS Date), 98, N'F', 2, N'AB123456C', 2, NULL, NULL, NULL, NULL, NULL, NULL, N'OX17 1EZ', N'OX17 1EZ', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+
+-- Learning Delivery
+INSERT [Valid].[LearningDelivery] ([LearnRefNumber], [LearnAimRef], [AimType], [AimSeqNumber], [LearnStartDate], [OrigLearnStartDate], [LearnPlanEndDate], [FundModel], [ProgType], [FworkCode], [PwayCode], [StdCode], [PartnerUKPRN], [DelLocPostCode], [AddHours], [PriorLearnFundAdj], [OtherFundAdj], [ConRefNumber], [EmpOutcome], [CompStatus], [LearnActEndDate], [WithdrawReason], [Outcome], [AchDate], [OutGrade], [SWSupAimId], [LrnDelFAM_ADL], [LrnDelFAM_ASL], [LrnDelFAM_EEF], [LrnDelFAM_FFI], [LrnDelFAM_FLN], [LrnDelFAM_HEM1], [LrnDelFAM_HEM2], [LrnDelFAM_HEM3], [LrnDelFAM_HHS1], [LrnDelFAM_HHS2], [LrnDelFAM_LDM1], [LrnDelFAM_LDM2], [LrnDelFAM_LDM3], [LrnDelFAM_LDM4], [LrnDelFAM_NSA], [LrnDelFAM_POD], [LrnDelFAM_RES], [LrnDelFAM_SOF], [LrnDelFAM_SPP], [LrnDelFAM_WPP], [ProvSpecMon_A], [ProvSpecMon_B], [ProvSpecMon_C], [ProvSpecMon_D]) 
+VALUES (N'1', N'ZPROG001', 1, 1, CAST(N'2017-06-01' AS Date), NULL, CAST(N'2017-06-01' AS Date), 36, 20, 550, 6, NULL, NULL, N'OX17 1EZ', NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, N'5def120a4e378040ac5d5ac2858700dd', NULL, NULL, NULL, N'2', NULL, NULL, NULL, NULL, NULL, NULL, N'129', NULL, NULL, NULL, NULL, NULL, NULL, N'105', NULL, NULL, NULL, NULL, NULL, NULL)
+
+-- LearningDeliveryFAM
+INSERT INTO [Valid].[LearningDeliveryFAM] ([LearnRefNumber], [AimSeqNumber], [LearnDelFAMType], [LearnDelFAMCode], [LearnDelFAMDateFrom], [LearnDelFAMDateTo]) 
+VALUES ('1', 1, 'ACT', '1', CAST(N'2017-06-01' AS Date), CAST(N'2017-06-01' AS Date))
+
+-- Earnings price episodes
+INSERT [Rulebase].[AEC_ApprenticeshipPriceEpisode] ([LearnRefNumber], [PriceEpisodeAimSeqNumber], [EpisodeStartDate], [PriceEpisodeIdentifier], [PriceEpisodeActualEndDate], [PriceEpisodeActualInstalments], [EpisodeEffectiveTNPStartDate], [PriceEpisodeCappedRemainingTNPAmount], [PriceEpisodeCompleted], [PriceEpisodeCompletionElement], [PriceEpisodeExpectedTotalMonthlyValue], [PriceEpisodeInstalmentValue], [PriceEpisodePlannedEndDate], [PriceEpisodePlannedInstalments], [PriceEpisodePreviousEarnings], [PriceEpisodeRemainingAmountWithinUpperLimit], [PriceEpisodeRemainingTNPAmount], [PriceEpisodeTotalEarnings], [PriceEpisodeTotalTNPPrice], [PriceEpisodeUpperBandLimit], [PriceEpisodeUpperLimitAdjustment], [TNP1], [TNP2], [TNP3], [TNP4] , [PriceEpisodeContractType]) 
+VALUES (N'1', 1, CAST(N'2017-06-01' AS Date), N'27-25-2017-06-01', NULL, NULL, CAST(N'2017-06-01' AS Date), NULL, NULL, CAST(300.00000 AS Decimal(10, 5)), NULL, CAST(100.00000 AS Decimal(10, 5)), CAST(N'2017-07-11' AS Date), NULL, NULL, NULL, NULL, NULL, CAST(15000.00000 AS Decimal(10, 5)), NULL, NULL, CAST(12000.00000 AS Decimal(10, 5)), CAST(3000.00000 AS Decimal(10, 5)), NULL, NULL,'Levy Contract')

--- a/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/Utilities/TestDataHelper.cs
+++ b/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.IntTests/Utilities/TestDataHelper.cs
@@ -353,9 +353,23 @@ namespace SFA.DAS.CollectionEarnings.DataLock.IntegrationTests.Utilities
             return GetPriceEpisodePeriodMatchForPeriod(connectionString, period);
         }
 
+        internal static CommitmentEntity[] GetProviderCommitmentsForIlrSubmission(long ukprn, bool inDeds = false)
+        {
+            var connectionString = inDeds
+                ? GlobalTestContext.Instance.SubmissionDedsConnectionString
+                : GlobalTestContext.Instance.SubmissionConnectionString;
+
+            return GetProviderCommitments(connectionString, ukprn);
+        }
+
         private static PriceEpisodeMatchEntity[] GetPriceEpisodePeriodMatches(string connectionString)
         {
             return Query<PriceEpisodeMatchEntity>(connectionString, "SELECT * FROM [DataLock].[PriceEpisodePeriodMatch]");
+        }
+
+        private static CommitmentEntity[] GetProviderCommitments(string connectionString, long ukprn)
+        {
+            return Query<CommitmentEntity>(connectionString, "SELECT * FROM DataLock.vw_Commitments WHERE ProviderUkprn = @ukprn", new { ukprn });
         }
 
         private static PriceEpisodePeriodMatchEntity[] GetPriceEpisodePeriodMatchForPeriod(string connectionString,int period)

--- a/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.UnitTests/Utilities/Entities/CommitmentEntityBuilder.cs
+++ b/src/SharedPipelineComponents/Datalock/SFA.DAS.CollectionEarnings.DataLock.UnitTests/Utilities/Entities/CommitmentEntityBuilder.cs
@@ -24,6 +24,32 @@ namespace SFA.DAS.CollectionEarnings.DataLock.UnitTests.Tools.Entities
         private DateTime? _effectiveTo;
         private int _priority;
 
+        public CommitmentEntityBuilder()
+        {
+            //
+        }
+
+        public CommitmentEntityBuilder(CommitmentEntityBuilder existingBuilder)
+        {
+            this._commitmentId = existingBuilder._commitmentId;
+            this._versionId = existingBuilder._versionId;
+            this._uln = existingBuilder._uln;
+            this._ukprn = existingBuilder._ukprn;
+            this._accountId = existingBuilder._accountId;
+            this._startDate = existingBuilder._startDate;
+            this._endDate = existingBuilder._endDate;
+            this._agreedCost = existingBuilder._agreedCost;
+            this._standardCode = existingBuilder._standardCode;
+            this._programmeType = existingBuilder._programmeType;
+            this._frameworkCode = existingBuilder._frameworkCode;
+            this._pathwayCode = existingBuilder._pathwayCode;
+            this._paymentStatus = existingBuilder._paymentStatus;
+            this._paymentStatusDescription = existingBuilder._paymentStatusDescription;
+            this._effectiveFrom = existingBuilder._effectiveFrom;
+            this._effectiveTo = existingBuilder._effectiveTo;
+            this._priority = existingBuilder._priority;
+        }
+
         public CommitmentEntity Build()
         {
             return new CommitmentEntity
@@ -44,7 +70,7 @@ namespace SFA.DAS.CollectionEarnings.DataLock.UnitTests.Tools.Entities
                 PaymentStatusDescription = _paymentStatusDescription,
                 EffectiveFrom = _effectiveFrom,
                 EffectiveTo = _effectiveTo,
-                Priority=_priority
+                Priority = _priority
             };
         }
 
@@ -134,8 +160,7 @@ namespace SFA.DAS.CollectionEarnings.DataLock.UnitTests.Tools.Entities
         public CommitmentEntityBuilder WithPaymentStatus(PaymentStatus paymentStatus)
         {
             _paymentStatus = (int)paymentStatus;
-            _paymentStatusDescription = paymentStatus.ToString();
-
+            _paymentStatusDescription = Enum.GetName(typeof(PaymentStatus), paymentStatus);
             return this;
         }
 
@@ -154,7 +179,7 @@ namespace SFA.DAS.CollectionEarnings.DataLock.UnitTests.Tools.Entities
         }
         public CommitmentEntityBuilder WithPriority(int priority)
         {
-            _priority= priority;
+            _priority = priority;
 
             return this;
         }


### PR DESCRIPTION
1. Added Spec to ensure we are excluding commitments which are started and ended on the same day.
2. Added unit tests for the above