### PR TITLE
DPP-1213 fix submission events when no valid learners (#173)

### DIFF
--- a/src/PeriodEnd/LevyPayments/SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests/GlobalTestContext.cs
+++ b/src/PeriodEnd/LevyPayments/SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests/GlobalTestContext.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests
         public string DatabaseName { get; private set; }
         public string BracketedDatabaseName { get; private set; }
         public string AssemblyDirectory { get; private set; }
+        public string LinkedServerName => "SELF";
 
 
 

--- a/src/PeriodEnd/LevyPayments/SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests/Utilities/TestDataHelper.cs
+++ b/src/PeriodEnd/LevyPayments/SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests/Utilities/TestDataHelper.cs
@@ -273,11 +273,13 @@ namespace SFA.DAS.ProviderPayments.Calc.LevyPayments.IntegrationTests.Tools
         private static string ReplaceSqlTokens(string sql)
         {
             return sql.Replace("${DAS_Accounts.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
-                      .Replace("${DAS_Commitments.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
-                      .Replace("${ILR_Summarisation.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
-                    .Replace("${DAS_PeriodEnd.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
-                    .Replace("${ILR_Deds.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
-                    .Replace("${YearOfCollection}", "1617");
+                .Replace("${DAS_Commitments.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
+                .Replace("${ILR_Summarisation.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
+                .Replace("${DAS_PeriodEnd.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
+                .Replace("${DAS_PeriodEnd.servername}", GlobalTestContext.Instance.LinkedServerName)
+                .Replace("${DAS_PeriodEnd.databasename}", GlobalTestContext.Instance.BracketedDatabaseName)
+                .Replace("${ILR_Deds.FQ}", GlobalTestContext.Instance.BracketedDatabaseName)
+                .Replace("${YearOfCollection}", "1617");
 
         }
     }

--- a/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission.IntegrationTests/Specs/WhenANewIlrFileIsSubmitted.cs
+++ b/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission.IntegrationTests/Specs/WhenANewIlrFileIsSubmitted.cs
@@ -92,6 +92,24 @@ namespace SFA.DAS.Provider.Events.Submission.IntegrationTests.Specs
         }
 
         [Test]
+        public void AndThereAreNoValidLearnersThenItShouldNotStoreLastSeenVersions()
+        {
+            // Arrange
+            var testDataSet = TestDataSet.GetFirstSubmissionDataset();
+            testDataSet.Learners.Clear();
+            testDataSet.Clean();
+            testDataSet.Store();
+
+            // Act
+            TaskRunner.RunTask();
+
+            // Assert
+            var lastSeenVersions = LastSeenVersionRepository.GetLastestVersionsForProvider(testDataSet.Providers[0].Ukprn);
+            Assert.IsNotNull(lastSeenVersions);
+            Assert.AreEqual(0, lastSeenVersions.Length);
+        }
+
+        [Test]
         public void ThenItShouldWriteIlrDetailsToLastSeenVersion()
         {
             // Arrange

--- a/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission.UnitTests/Application/WriteLastSeenIlrDetails/WriteLastSeenIlrDetailsCommandHandlerTests/WhenHandlingWriteLastSeenIlrDetailsCommand.cs
+++ b/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission.UnitTests/Application/WriteLastSeenIlrDetails/WriteLastSeenIlrDetailsCommandHandlerTests/WhenHandlingWriteLastSeenIlrDetailsCommand.cs
@@ -31,5 +31,15 @@ namespace SFA.DAS.Provider.Events.Submission.UnitTests.Application.WriteLastSeen
             // Assert
             _ilrSubmissionRepository.Verify(r => r.StoreLastSeenVersions(It.Is<IlrDetails[]>(x => x[0] == _ilr)), Times.Once);
         }
+
+        [Test]
+        public void ThenItShouldNotCallDbIfNothingToStore()
+        {
+            // Act
+            _handler.Handle(new WriteLastSeenIlrDetailsCommand { LastSeenIlrs = new IlrDetails[0] });
+
+            // Assert
+            _ilrSubmissionRepository.Verify(r => r.StoreLastSeenVersions(It.IsAny<IlrDetails[]>()), Times.Never, "Repository method was called when nothing to save");
+        }
     }
 }

--- a/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/Application/WriteLastSeenIlrDetails/WriteLastSeenIlrDetailsCommandHandler.cs
+++ b/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/Application/WriteLastSeenIlrDetails/WriteLastSeenIlrDetailsCommandHandler.cs
@@ -14,7 +14,8 @@ namespace SFA.DAS.Provider.Events.Submission.Application.WriteLastSeenIlrDetails
 
         public Unit Handle(WriteLastSeenIlrDetailsCommand message)
         {
-            _ilrSubmissionRepository.StoreLastSeenVersions(message.LastSeenIlrs);
+            if (message.LastSeenIlrs != null && message.LastSeenIlrs.Length > 0)
+                _ilrSubmissionRepository.StoreLastSeenVersions(message.LastSeenIlrs);
 
             return Unit.Value;
         }

--- a/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/Infrastructure/Data/DcfsIlrSubmissionRepository.cs
+++ b/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/Infrastructure/Data/DcfsIlrSubmissionRepository.cs
@@ -30,6 +30,9 @@ namespace SFA.DAS.Provider.Events.Submission.Infrastructure.Data
 
         public void StoreLastSeenVersions(IlrDetails[] details)
         {
+            if (details == null || details.Length == 0)
+                return;
+
             using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();

--- a/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/SubmissionEventsProcessor.cs
+++ b/src/SharedPipelineComponents/IlrSubmissionEvents/SFA.DAS.Provider.Events.Submission/SubmissionEventsProcessor.cs
@@ -37,10 +37,13 @@ namespace SFA.DAS.Provider.Events.Submission
                 _logger.Error(currentVersions.Exception, "Error getting current versions");
                 throw currentVersions.Exception;
             }
+
             if (!currentVersions.HasAnyItems())
             {
                 _logger.Info("Did not find any current versions. Exiting");
+                return;
             }
+
             _logger.Info($"Found {currentVersions.Items.Length} current versions");
 
             var lastSeenVersions = _mediator.Send(new GetLastSeenVersionsQuery());


### PR DESCRIPTION
* Unit and integration tests to reproduce the problem and the fix.

* Fix for tests that use openquery but somehow passed without new tokens