### PR TITLE
DPP-1318 Speed up acceptance tests

### DIFF
--- a/src/AcceptanceTesting/Features/change_in_circumstances.feature
+++ b/src/AcceptanceTesting/Features/change_in_circumstances.feature
@@ -15,10 +15,10 @@ Feature: Provider earnings and payments where learner changes apprenticeship sta
             | ULN       | standard code | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date |
             | learner a | 51            | 03/08/2017 | 01/08/2018       | 31/10/2017      | withdrawn         | 12000                | 03/08/2017                          | 3000                   | 03/08/2017                            |
             | learner a | 52            | 03/11/2017 | 01/08/2018       |                 | continuing        | 4500                 | 03/11/2017                          | 1125                   | 03/11/2017                            |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
+        Then the provider earnings and payments break down as follows:
             | Type                       | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total      | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA   | 1000  | 1000  | 1000  | 500   | 500   |
@@ -191,11 +191,11 @@ Feature: Provider earnings and payments where learner changes apprenticeship sta
             | learner a | 51            | 03/08/2017 | 04/08/2018       | 10/11/2017      | withdrawn         | 12000                  | 03/08/2017                            | 3000                     | 03/08/2017                              |
             | learner a | 52            | 11/11/2017 | 04/08/2018       |                 | continuing        | 4500                   | 11/11/2017                            | 1125                     | 11/11/2017                              | 
         
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
    
-        And the provider earnings and payments break down as follows:
+        Then the provider earnings and payments break down as follows:
             | Type                       | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total      | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA       | 0     | 1000  | 1000  | 1000  | 500   |
@@ -255,11 +255,11 @@ Scenario: Earnings and payments for a DAS learner, levy available, where the app
             | learner a | 51            | 03/08/2017 | 04/08/2018       | 18/11/2017      | withdrawn         | 12000                  | 03/08/2017                            | 3000                     | 03/08/2017                              |
             | learner a | 52            | 19/11/2017 | 04/08/2018       |                 | continuing        | 4500                   | 19/11/2017                            | 1125                     | 19/11/2017                              | 
         
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 |
    
-        And the provider earnings and payments break down as follows:         
+        Then the provider earnings and payments break down as follows:         
             | Type                       | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total      | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA       | 0     | 1000  | 1000  | 1000  | 500   |
@@ -277,11 +277,11 @@ Scenario: Earnings and payments for a DAS learner, levy available, where the app
             | learner a | 51            | 03/08/2017 | 04/08/2018       | 04/12/2017      | withdrawn         | 12000                  | 03/08/2017                            | 3000                     | 03/08/2017                              |
             | learner a | 52            | 05/12/2017 | 04/08/2018       |                 | continuing        | 4500                   | 05/12/2017                            | 1125                     | 05/12/2017                              | 
         
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17               | 01/18               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 1 v1-002 | commitment 1 v1-002 |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17               | 01/18               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 1 v1-002 | commitment 1 v1-002 |
    
-        And the provider earnings and payments break down as follows:         
+        Then the provider earnings and payments break down as follows:         
             | Type                       | 08/17 | 09/17 | 10/17 | 11/17 | 12/17  | 01/18  |
             | Provider Earned Total      | 1000  | 1000  | 1000  | 1000  | 562.50 | 562.50 |
             | Provider Paid by SFA       | 0     | 1000  | 1000  | 1000  | 0      | 562.50 |
@@ -324,16 +324,16 @@ Scenario:630-AC01  Earnings and payments for a DAS learner, levy available, and 
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | standard code | Total training price 1 | Total training price 1 effective date | Total assessment price 1 | Total assessment price 1 effective date | Total assessment price 2 | Total assessment price 2 effective date |
             | learner a | 05/08/2017 | 28/08/2018       |                 | continuing        | 11            | 12000                  | 05/08/2017                            | 3500                     | 05/08/2017                              | 4000                     | 15/11/2017                              |
-		Then the data lock status will be as follows:
-			| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-			| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
-			| Completion                     |                     |                     |                     |                     |                     |                     |
-			| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider learning support      |                     |                     |                     |                     |                     |                     |
-			| English and maths on programme |                     |                     |                     |                     |                     |                     |
-			| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
-        And the provider earnings and payments break down as follows:
+		#Then the data lock status will be as follows:
+		#	| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+		#	| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
+		#	| Completion                     |                     |                     |                     |                     |                     |                     |
+		#	| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider learning support      |                     |                     |                     |                     |                     |                     |
+		#	| English and maths on programme |                     |                     |                     |                     |                     |                     |
+		#	| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
+        Then the provider earnings and payments break down as follows:
             | Type                          | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   |
             | Provider Earned Total         | 1033.33 | 1033.33 | 1033.33 | 1077.78 | 1077.78 | 1077.78 |
             | Provider Earned from SFA      | 1033.33 | 1033.33 | 1033.33 | 1077.78 | 1077.78 | 1077.78 |
@@ -358,16 +358,16 @@ Scenario:630-AC02  Earnings and payments for a DAS learner, levy available, and 
 			| ULN       | start date | planned end date | actual end date | completion status | standard code | Total training price 1 | Total training price 1 effective date | Total assessment price 1 | Total assessment price 1 effective date | Total assessment price 2 | Total assessment price 2 effective date |
 			| learner a | 05/08/2017 | 28/08/2018       |                 | continuing        | 11            | 12000                  | 05/08/2017                            | 3500                     | 05/08/2017                              | 2000                     | 15/11/2017                              |
         
-		Then the data lock status will be as follows:
-			| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-			| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
-			| Completion                     |                     |                     |                     |                     |                     |                     |
-			| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider learning support      |                     |                     |                     |                     |                     |                     |
-			| English and maths on programme |                     |                     |                     |                     |                     |                     |
-			| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
-		And the provider earnings and payments break down as follows:
+		#Then the data lock status will be as follows:
+		#	| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+		#	| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
+		#	| Completion                     |                     |                     |                     |                     |                     |                     |
+		#	| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider learning support      |                     |                     |                     |                     |                     |                     |
+		#	| English and maths on programme |                     |                     |                     |                     |                     |                     |
+		#	| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
+		Then the provider earnings and payments break down as follows:
 			| Type                          | 08/17   | 09/17   | 10/17   | 11/17   | 12/17  | 01/18  |
 			| Provider Earned Total         | 1033.33 | 1033.33 | 1033.33 | 900.00  | 900.00 | 900.00 |
 			| Provider Earned from SFA      | 1033.33 | 1033.33 | 1033.33 | 900.00  | 900.00 | 900.00 |
@@ -391,16 +391,16 @@ Scenario:630-AC03  Earnings and payments for a DAS learner, levy available, and 
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | standard code | Residual training price 1 | Residual training price 1 effective date | Residual assessment price 1 | Residual assessment price 1 effective date | Residual assessment price 2 | Residual assessment price 2 effective date |
             | learner a | 05/08/2017 | 28/08/2018       |                 | continuing        | 11            | 12000                     | 05/08/2017                               | 3500                        | 05/08/2017                                 | 4000                        | 15/11/2017                                 |
-  		Then the data lock status will be as follows:
-		   | Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-		   | On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
-		   | Completion                     |                     |                     |                     |                     |                     |                     |
-		   | Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-		   | Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-		   | Provider learning support      |                     |                     |                     |                     |                     |                     |
-		   | English and maths on programme |                     |                     |                     |                     |                     |                     |
-		   | English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
-        And the provider earnings and payments break down as follows:
+  		#Then the data lock status will be as follows:
+		  # | Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+		  # | On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
+		  # | Completion                     |                     |                     |                     |                     |                     |                     |
+		  # | Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		  # | Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		  # | Provider learning support      |                     |                     |                     |                     |                     |                     |
+		  # | English and maths on programme |                     |                     |                     |                     |                     |                     |
+		  # | English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
+        Then the provider earnings and payments break down as follows:
             | Type                          | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   |
             | Provider Earned Total         | 1033.33 | 1033.33 | 1033.33 | 1422.22 | 1422.22 | 1422.22 |
             | Provider Earned from SFA      | 1033.33 | 1033.33 | 1033.33 | 1422.22 | 1422.22 | 1422.22 |
@@ -423,16 +423,16 @@ Scenario:630-AC04  Earnings and payments for a DAS learner, levy available, and 
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | standard code | Residual training price 1 | Residual training price 1 effective date | Residual assessment price 1 | Residual assessment price 1 effective date | Residual assessment price 2 | Residual assessment price 2 effective date |
             | learner a | 05/08/2017 | 28/08/2018       |                 | continuing        | 11            | 12000                     | 05/08/2017                               | 3500                        | 05/08/2017                                 | 2000                        | 15/11/2017                                 |
-		Then the data lock status will be as follows:
-			| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-			| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
-			| Completion                     |                     |                     |                     |                     |                     |                     |
-			| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider learning support      |                     |                     |                     |                     |                     |                     |
-			| English and maths on programme |                     |                     |                     |                     |                     |                     |
-			| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
-	   And the provider earnings and payments break down as follows:
+		#Then the data lock status will be as follows:
+		#	| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+		#	| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
+		#	| Completion                     |                     |                     |                     |                     |                     |                     |
+		#	| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider learning support      |                     |                     |                     |                     |                     |                     |
+		#	| English and maths on programme |                     |                     |                     |                     |                     |                     |
+		#	| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
+	   Then the provider earnings and payments break down as follows:
 			| Type                          | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   |
 			| Provider Earned Total         | 1033.33 | 1033.33 | 1033.33 | 1244.44 | 1244.44 | 1244.44 |
 			| Provider Earned from SFA      | 1033.33 | 1033.33 | 1033.33 | 1244.44 | 1244.44 | 1244.44 |
@@ -456,16 +456,16 @@ Scenario:630-AC04  Earnings and payments for a DAS learner, levy available, and 
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | standard code | Total training price 1 | Total training price 1 effective date | Total assessment price 1 | Total assessment price 1 effective date | Total assessment price 2 | Total assessment price 2 effective date |
             | learner a | 05/08/2017 | 28/08/2018       |                 | continuing        | 11            | 15500                  | 05/08/2017                            | 0                        | 05/08/2017                              | 500                      | 15/11/2017                              |
-		Then the data lock status will be as follows:
-			| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-			| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
-			| Completion                     |                     |                     |                     |                     |                     |                     |
-			| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
-			| Provider learning support      |                     |                     |                     |                     |                     |                     |
-			| English and maths on programme |                     |                     |                     |                     |                     |                     |
-			| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
-        And the provider earnings and payments break down as follows:
+		#Then the data lock status will be as follows:
+		#	| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+		#	| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-002 | commitment 1 v1-002 | commitment 1 v1-002 |
+		#	| Completion                     |                     |                     |                     |                     |                     |                     |
+		#	| Employer 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider 16-18 incentive       |                     |                     |                     |                     |                     |                     |
+		#	| Provider learning support      |                     |                     |                     |                     |                     |                     |
+		#	| English and maths on programme |                     |                     |                     |                     |                     |                     |
+		#	| English and maths Balancing    |                     |                     |                     |                     |                     |                     | 
+        Then the provider earnings and payments break down as follows:
             | Type                          | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   |
             | Provider Earned Total         | 1033.33 | 1033.33 | 1033.33 | 1077.78 | 1077.78 | 1077.78 |
             | Provider Earned from SFA      | 1033.33 | 1033.33 | 1033.33 | 1077.78 | 1077.78 | 1077.78 |

--- a/src/AcceptanceTesting/Features/commitment_effectiveness.feature
+++ b/src/AcceptanceTesting/Features/commitment_effectiveness.feature
@@ -15,10 +15,10 @@ Feature: Commitment effective dates apply correctly in data collections processi
 			| ULN       | learner type       | start date | planned end date | completion status | Total training price 1 | Total training price 1 effective date | Total training price 2 | Total training price 2 effective date |
 			| learner a | programme only DAS | 12/05/2017 | 20/05/2018       | continuing        | 7500                   | 01/05/2017                            | 15000                  | 01/06/2017                            |
 
-		Then the data lock status will be as follows:
-            | Payment type | 05/17               | 06/17               | 07/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v2-001 | commitment 1 v2-001 |
-        And the provider earnings and payments break down as follows:
+		#Then the data lock status will be as follows:
+  #          | Payment type | 05/17               | 06/17               | 07/17               |
+  #          | On-program   | commitment 1 v1-001 | commitment 1 v2-001 | commitment 1 v2-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                          | 05/17 | 06/17   | 07/17   |
             | Provider Earned Total         | 500   | 1045.45 | 1045.45 |
             | Provider Earned from SFA      | 500   | 1045.45 | 1045.45 |
@@ -40,9 +40,9 @@ Feature: Commitment effective dates apply correctly in data collections processi
 			| ULN       | learner type       | start date | planned end date | completion status | Total training price 1 | Total training price 1 effective date | Total training price 2 | Total training price 2 effective date |
 			| learner a | programme only DAS | 12/05/2017 | 20/05/2018       | continuing        | 7500                   | 01/05/2017                            | 15000                  | 01/06/2017                            |
 
-		Then the data lock status will be as follows:
-            | Payment type | 05/17               | 06/17               | 07/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v2-001 | commitment 1 v3-001 |
+		#Then the data lock status will be as follows:
+  #          | Payment type | 05/17               | 06/17               | 07/17               |
+  #          | On-program   | commitment 1 v1-001 | commitment 1 v2-001 | commitment 1 v3-001 |
         Then the provider earnings and payments break down as follows:
             | Type                          | 05/17 | 06/17   | 07/17   |
             | Provider Earned Total         | 500   | 1045.45 | 1045.45 |
@@ -65,9 +65,9 @@ Feature: Commitment effective dates apply correctly in data collections processi
 			| ULN       | learner type       | start date | planned end date | completion status | Total training price 1 | Total training price 1 effective date | 
 			| learner a | programme only DAS | 12/05/2017 | 20/05/2018       | continuing        | 7500                   | 01/05/2017                            | 
 
-		Then the data lock status will be as follows:
-            | Payment type | 05/17               | 06/17               | 07/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v3-001 | commitment 1 v3-001 |
+		#Then the data lock status will be as follows:
+  #          | Payment type | 05/17               | 06/17               | 07/17               |
+  #          | On-program   | commitment 1 v1-001 | commitment 1 v3-001 | commitment 1 v3-001 |
         Then the provider earnings and payments break down as follows:
             | Type                       | 05/17 | 06/17 | 07/17 |
             | Provider Earned Total      | 500   | 500   | 500   |

--- a/src/AcceptanceTesting/Features/employer_stops_payments.feature
+++ b/src/AcceptanceTesting/Features/employer_stops_payments.feature
@@ -85,17 +85,17 @@ Scenario:700_AC02 DAS learner, payments are allowed as the employer has previous
             |ULN       | learner type       | agreed price | start date | planned end date | actual end date | completion status |
             |learner a | programme only DAS | 15000        | 05/08/2017 | 20/08/2018       |                 | continuing        |
       
-		Then the data lock status will be as follows:
-			| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-			| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |
-			| Completion                     |                     |                     |                     |                     |                     |
-			| Employer 16-18 incentive       |                     |                     |                     |                     |                     |
-			| Provider 16-18 incentive       |                     |                     |                     |                     |                     |
-			| Provider learning support      |                     |                     |                     |                     |                     |
-			| English and maths on programme |                     |                     |                     |                     |                     |
-			| English and maths Balancing    |                     |                     |                     |                     |                     |     
+		#Then the data lock status will be as follows:
+		#	| Payment type                   | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+		#	| On-program                     | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |
+		#	| Completion                     |                     |                     |                     |                     |                     |
+		#	| Employer 16-18 incentive       |                     |                     |                     |                     |                     |
+		#	| Provider 16-18 incentive       |                     |                     |                     |                     |                     |
+		#	| Provider learning support      |                     |                     |                     |                     |                     |
+		#	| English and maths on programme |                     |                     |                     |                     |                     |
+		#	| English and maths Balancing    |                     |                     |                     |                     |                     |     
 
-		And OBSOLETE - the provider earnings and payments break down as follows:
+		Then OBSOLETE - the provider earnings and payments break down as follows:
             | Type                          | 08/17 | 09/17 | 10/17 | 
             | Provider Earned Total         | 1000  | 1000  | 1000  | 
             | Provider Earned from SFA      | 900   | 900   | 900   |

--- a/src/AcceptanceTesting/Features/learner_changes_employer.feature
+++ b/src/AcceptanceTesting/Features/learner_changes_employer.feature
@@ -19,10 +19,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 01/08/2017 | 04/08/2018       |                 | continuing        | 12000                | 01/08/2017                          | 3000                   | 01/08/2017                            | 5000                    | 01/11/2017                             | 625                       | 01/11/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 500   | 500   |
@@ -54,10 +54,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 04/08/2017 | 04/08/2018       |                 | continuing        | 12000                | 04/08/2017                          | 3000                   | 04/08/2017                            | 5000                    | 10/11/2017                             | 625                       | 10/11/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 500   | 500   |
@@ -88,10 +88,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 04/08/2017 | 04/08/2018       |                 | continuing        | 12000                | 04/08/2017                          | 3000                   | 04/08/2017                            | 5000                    | 25/10/2017                             | 625                       | 25/10/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17 | 12/17 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17 | 11/17 | 12/17 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 450   | 450   | 450   |
             | Provider Earned from SFA        | 1000  | 1000  | 450   | 450   | 450   |
@@ -124,10 +124,10 @@ Feature: Provider earnings and payments where a learner changes employers
             | contract type | date from  | date to    |
             | DAS           | 03/08/2017 | 02/11/2017 |
             | Non-DAS       | 03/11/2017 | 04/08/2018 |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 450   | 450   |
@@ -161,10 +161,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 01/08/2017 | 28/08/2018       |                 | continuing        | 12000                | 01/08/2017                          | 3000                   | 01/08/2017                            | 5000                    | 15/11/2017                             | 625                       | 15/11/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 500   | 500   |
@@ -195,10 +195,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 01/08/2017 | 28/08/2018       |                 | continuing        | 12000                | 01/08/2017                          | 3000                   | 01/08/2017                            | 5000                    | 25/11/2017                             | 625                       | 25/11/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 500   | 500   |
@@ -229,10 +229,10 @@ Feature: Provider earnings and payments where a learner changes employers
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 01/08/2017 | 28/08/2018       |                 | continuing        | 12000                | 01/08/2017                          | 3000                   | 01/08/2017                            | 5000                    | 05/11/2017                             | 625                       | 05/11/2017                               |
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 500   | 500   |
@@ -264,10 +264,10 @@ Feature: Provider earnings and payments where a learner changes employers
             | contract type | date from  | date to    |
             | Non-DAS       | 06/08/2017 | 31/03/2018 |
             | DAS           | 01/04/2018 | 08/08/2018 |
-        Then the data lock status will be as follows:
-            | Payment type | 08/17 | 09/17 | 10/17 | ... | 03/18 | 04/18               | 05/18               | 06/18               | 07/18               | 
-            | On-program   |       |       |       | ... |       | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | 
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17 | 09/17 | 10/17 | ... | 03/18 | 04/18               | 05/18               | 06/18               | 07/18               | 
+        #    | On-program   |       |       |       | ... |       | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | 
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | ... | 03/18 | 04/18 | 05/18 | 06/18 | 07/18 | 08/18 |
             | Provider Earned Total           | 400   | 400   | 400   | ... | 400   | 700   | 700   | 700   | 700   | 0     |
             | Provider Earned from SFA        | 360   | 360   | 360   | ... | 360   | 700   | 700   | 700   | 700   | 0     |
@@ -334,10 +334,10 @@ Feature: Provider earnings and payments where a learner changes employers
             | learner a | 01/08/2017 | 04/08/2018       | 31/10/2017      | withdrawn         | 12000                | 01/08/2017                          | 3000                   | 01/08/2017                            |                         |                                        |                           |                                          |
             | learner a | 01/01/2018 | 04/10/2018       |                 | continuing        |                      |                                     |                        |                                       | 5000                    | 01/01/2018                             | 625                       | 01/01/2018                               |
            
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18               | 02/18               | 03/18               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18               | 02/18               | 03/18               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 | 03/18 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 0     | 0     | 500   | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 0     | 0     | 500   | 500   | 500   |
@@ -371,10 +371,10 @@ Feature: Provider earnings and payments where a learner changes employers
             | learner a | 03/08/2017 | 04/08/2018       | 18/11/2017      | withdrawn         | 12000                | 03/08/2017                          | 3000                   | 03/08/2017                            |                         |                                        |                           |                                          |
             | learner a | 11/01/2018 | 04/10/2018       |                 | continuing        |                      |                                     |                        |                                       | 5000                    | 11/01/2018                             | 625                       | 11/01/2018                               |
            
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18               | 02/18               | 03/18               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18               | 02/18               | 03/18               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 | 03/18 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 0     | 0     | 500   | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 0     | 0     | 500   | 500   | 500   |
@@ -407,10 +407,10 @@ Scenario: Earnings and payments for a DAS learner, levy available, and they have
             | learner a | 03/08/2017 | 04/08/2018       | 18/11/2017      | withdrawn         | 12000                | 03/08/2017                          | 3000                   | 03/08/2017                            |                         |                                        |                           |                                          |
             | learner a | 21/12/2017 | 04/09/2018       |                 | continuing        |                      |                                     |                        |                                       | 5000                    | 21/12/2017                             | 625                       | 21/12/2017                               |
            
-        Then the data lock status of the ILR in 03/12/2017 is:
-            | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18 | 02/18 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |       |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status of the ILR in 03/12/2017 is:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | 11/17 | 12/17 | 01/18 | 02/18 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |       |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 0     | 500   | 500   | 500   |
             | Provider Earned from SFA        | 1000  | 1000  | 1000  | 0     | 0     | 0     | 0     |
@@ -446,13 +446,13 @@ Scenario: 1 learner aged 16-18, levy available, changes employer, earns incentiv
             | Provider   | learner type             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       |                 | continuing        | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            | 4000                    | 15/11/2017                             | 1625                      | 15/11/2017                               |
             
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+        #Then the data lock status will be as follows:
+        #    | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+        #    | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        #    | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+        #    | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
         
-        And the earnings and payments break down for provider a is as follows:
+        Then the earnings and payments break down for provider a is as follows:
             | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 |
             | Provider Earned Total               | 500   | 500   | 500   | 1500  | 500   | 500   |
             | Provider Earned from SFA            | 500   | 500   | 500   | 1500  | 500   | 500   |
@@ -497,13 +497,13 @@ Scenario: 1 learner aged 16-18, levy available, changes employer, earns incentiv
             | Provider   | learner type             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       |                 | continuing        | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            | 4000                    | 15/12/2017                             | 1625                      | 15/12/2017                               |
 
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     | commitment 2 v1-001 | commitment 2 v1-001 |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+        #Then the data lock status will be as follows:
+        #    | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+        #    | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     | commitment 2 v1-001 | commitment 2 v1-001 |
+        #    | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+        #    | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
         
-        And the earnings and payments break down for provider a is as follows:
+        Then the earnings and payments break down for provider a is as follows:
             | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17  | 01/18  |
             | Provider Earned Total               | 500   | 500   | 500   | 1500  | 562.50 | 562.50 |
             | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 562.50 | 562.50 |
@@ -548,13 +548,13 @@ Scenario: 1 learner aged 16-18, levy available, changes employer, earns incentiv
             | Provider   | learner type             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       |                 | continuing        | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            | 4000                    | 09/11/2017                             | 1625                      | 09/11/2017                               |
     
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17 | 01/18 |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     |       |       |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |
+        #Then the data lock status will be as follows:
+        #    | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17 | 01/18 |
+        #    | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     |       |       |
+        #    | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |
+        #    | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |
         
-        And the earnings and payments break down for provider a is as follows:
+        Then the earnings and payments break down for provider a is as follows:
             | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 |
             | Provider Earned Total               | 500   | 500   | 500   | 1500  | 500   | 500   |
             | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     | 0     |
@@ -611,10 +611,10 @@ Scenario:AC1- Provider earnings and payments where learner changes employer and 
             |            | not in paid employment | 03/10/2017                |
             | employer 2 | in paid employment     | 03/11/2017                |         
      
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA            | 0     | 1000  | 1000  | 1000  | 500   |
@@ -653,10 +653,10 @@ Scenario:AC2- Provider earnings and payments where learner changes employer and 
         And the employment status in the ILR is:
             | Employer   | Employment Status      | Employment Status Applies |
             | employer 1 | in paid employment     | 02/08/2017                |
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA            | 0     | 1000  | 1000  | 0     | 500   |
@@ -694,10 +694,10 @@ Scenario:AC3- Provider earnings and payments where learner changes employer and 
         And the employment status in the ILR is:
             | Employer   | Employment Status      | Employment Status Applies |
             | employer 1 | in paid employment     | 02/08/2017                |
-         Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+         #Then the data lock status will be as follows:
+         #   | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
+         #   | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA            | 0     | 1000  | 1000  | 900   | 500   |
@@ -737,10 +737,10 @@ Scenario: AC4-Provider earnings and payments where learner changes employer and 
             | employer 1 | in paid employment     | 02/08/2017                |
             |            | not in paid employment | 03/10/2017                |
             | employer 2 | in paid employment     | 03/11/2017                |
-         Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
-        And the provider earnings and payments break down as follows:
+         #Then the data lock status will be as follows:
+         #   | Payment type | 08/17               | 09/17               | 10/17 | 11/17               | 12/17               |
+         #   | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 500   | 500   |
             | Provider Paid by SFA            | 0     | 1000  | 1000  | 0     | 500   |
@@ -783,10 +783,10 @@ Scenario:AC5-Provider earnings and payments where learner changes employer and t
             |            | not in paid employment | 09/10/2017                |
             | employer 2 | in paid employment     | 02/03/2018                |
      
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 | 03/18 | 04/18 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |       |       |       |       |
-        And the provider earnings and payments break down as follows:
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 | 03/18 | 04/18 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 |       |       |       |       |       |       |       |
+        Then the provider earnings and payments break down as follows:
             | Type                            | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 | 03/18 | 04/18 |
             | Provider Earned Total           | 1000  | 1000  | 1000  | 1000  | 1000  | 0     | 0     | 0     | 0     |
             | Provider Paid by SFA            | 0     | 1000  | 1000  | 1000  | 1000  | 1000  | 0     | 0     | 0     |

--- a/src/AcceptanceTesting/Features/learner_changes_provider.feature
+++ b/src/AcceptanceTesting/Features/learner_changes_provider.feature
@@ -15,33 +15,33 @@ Feature: Apprentice changes provider scenarios
             | provider a | learner a | 06/08/2017 | 08/08/2018       | 04/03/2018      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |
             | provider b | learner a | 06/06/2018 | 20/11/2018       |                 | continuing        | 3000                 | 06/06/2018                          | 1500                   | 06/06/2018                            |
         
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18               | 03/18 | 04/18 | 05/18 | 06/18               | 07/18               | 08/18               | 09/18               | 10/18               | 
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       |       |       | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | 
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18               | 03/18 | 04/18 | 05/18 | 06/18               | 07/18               | 08/18               | 09/18               | 10/18               | 
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       |       |       | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | commitment 2 v2-001 | 
         
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 |
-            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   |
-            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     |
-            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   |
-            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     |
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 | 04/18 | ... | 11/18 |
+            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
         
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                           | 06/18 | 07/18 | 08/18 | 09/18 | 10/18 | 11/18 |
-            | Provider Earned Total          | 720   | 720   | 720   | 720   | 720   | 0     |
-            | Provider Earned from SFA       | 720   | 720   | 720   | 720   | 720   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 720   | 720   | 720   | 720   | 720   |
-            | Payment due from Employer      | 0     | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited           | 0     | 720   | 720   | 720   | 720   | 720   |
-            | SFA Levy employer budget       | 720   | 720   | 720   | 720   | 720   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Type                           | 08/17 | ... | 06/18 | 07/18 | 08/18 | 09/18 | 10/18 | 11/18 |
+            | Provider Earned Total          | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | Provider Earned from SFA       | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | Provider Earned from Employer  | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA           | 0     | ... | 0     | 720   | 720   | 720   | 720   | 720   |
+            | Payment due from Employer      | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited           | 0     | ... | 0     | 720   | 720   | 720   | 720   | 720   |
+            | SFA Levy employer budget       | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | SFA Levy co-funding budget     | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
 
 
     Scenario: Apprentice changes provider but remains with the same employer
@@ -57,31 +57,31 @@ Feature: Apprentice changes provider scenarios
             | Provider   | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date |
             | provider a | learner a | 06/08/2017 | 08/08/2018       | 04/03/2018      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |
             | provider b | learner a | 05/03/2018 | 20/08/2018       |                 | continuing        | 3000                 | 05/03/2018                          | 1500                   | 05/03/2018                            |
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18               | 03/18               | 04/18               | 05/18               | 06/18               | 07/18               | 
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | 
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 |
-            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   |
-            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     |
-            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   |
-            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18               | 03/18               | 04/18               | 05/18               | 06/18               | 07/18               | 
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | 
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 | 04/18 | ... | 11/18 |
+            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                           | 03/18 | 04/18 | 05/18 | 06/18 | 07/18 | 08/18 |
-            | Provider Earned Total          | 720   | 720   | 720   | 720   | 720   | 0     |
-            | Provider Earned from SFA       | 720   | 720   | 720   | 720   | 720   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 720   | 720   | 720   | 720   | 720   |
-            | Payment due from Employer      | 0     | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited           | 0     | 720   | 720   | 720   | 720   | 720   |
-            | SFA Levy employer budget       | 720   | 720   | 720   | 720   | 720   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Type                           | 08/17 | ... | 03/18 | 04/18 | 05/18 | 06/18 | 07/18 | 08/18 |
+            | Provider Earned Total          | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | Provider Earned from SFA       | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | Provider Earned from Employer  | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA           | 0     | ... | 0     | 720   | 720   | 720   | 720   | 720   |
+            | Payment due from Employer      | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited           | 0     | ... | 0     | 720   | 720   | 720   | 720   | 720   |
+            | SFA Levy employer budget       | 0     | ... | 720   | 720   | 720   | 720   | 720   | 0     |
+            | SFA Levy co-funding budget     | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget | 0     | ... | 0     | 0     | 0     | 0     | 0     | 0     |
 
 
     Scenario: Apprentice changes provider but remains with the same employer, ILR changes after the new commitment is in place
@@ -97,31 +97,31 @@ Feature: Apprentice changes provider scenarios
             | Provider   | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date |
             | provider a | learner a | 06/08/2017 | 08/08/2018       | 04/04/2018      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |
             | provider b | learner a | 05/04/2018 | 08/08/2018       |                 | continuing        | 3000                 | 05/04/2018                          | 1500                   | 05/04/2018                            |
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18           | 03/18 | 04/18               | 05/18               | 06/18               | 07/18               | 
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | 
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 | 04/18 |
-            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 500   | 0     |
-            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   | 0     |
-            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     | 0     |
-            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   | 0     |
-            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     | 0     |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | ... | 02/18           | 03/18 | 04/18               | 05/18               | 06/18               | 07/18               | 
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | 
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                           | 08/17 | 09/17 | 10/17 | ... | 02/18 | 03/18 | 04/18 | ... | 11/18 |
+            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                           | 04/18 | 05/18 | 06/18 | 07/18 | 08/18 |
-            | Provider Earned Total          | 900   | 900   | 900   | 900   | 0     |
-            | Provider Earned from SFA       | 900   | 900   | 900   | 900   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 900   | 900   | 900   | 900   |
-            | Payment due from Employer      | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited           | 0     | 900   | 900   | 900   | 900   |
-            | SFA Levy employer budget       | 900   | 900   | 900   | 900   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | 0     | 0     |
+            | Type                           | 08/17 | ... | 04/18 | 05/18 | 06/18 | 07/18 | 08/18 |
+            | Provider Earned Total          | 0     | ... | 900   | 900   | 900   | 900   | 0     |
+            | Provider Earned from SFA       | 0     | ... | 900   | 900   | 900   | 900   | 0     |
+            | Provider Earned from Employer  | 0     | ... | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA           | 0     | ... | 0     | 900   | 900   | 900   | 900   |
+            | Payment due from Employer      | 0     | ... | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited           | 0     | ... | 0     | 900   | 900   | 900   | 900   |
+            | SFA Levy employer budget       | 0     | ... | 900   | 900   | 900   | 900   | 0     |
+            | SFA Levy co-funding budget     | 0     | ... | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget | 0     | ... | 0     | 0     | 0     | 0     | 0     |
 
 
     Scenario: Apprentice changes provider but remains with the same employer, ILR changes before the new commitment is in place
@@ -137,31 +137,31 @@ Feature: Apprentice changes provider scenarios
             | Provider   | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date |
             | provider a | learner a | 06/08/2017 | 08/08/2018       | 04/02/2018      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |
             | provider b | learner a | 05/02/2018 | 20/08/2018       |                 | continuing        | 3000                 | 05/02/2018                          | 1500                   | 05/02/2018                            |
-        Then the data lock status will be as follows:
-            | Payment type | 08/17               | 09/17               | 10/17               | ... | 01/18               | 02/18 | 03/18 | 04/18 | ... | 07/18 | 08/18 |
-            | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       |       |       | ... |       |       |
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                           | 08/17 | 09/17 | 10/17 | ... | 01/18 | 02/18 |
-            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   |
-            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     |
-            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   |
-            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     |
+        #Then the data lock status will be as follows:
+        #    | Payment type | 08/17               | 09/17               | 10/17               | ... | 01/18               | 02/18 | 03/18 | 04/18 | ... | 07/18 | 08/18 |
+        #    | On-program   | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | ... | commitment 1 v1-001 |       |       |       | ... |       |       |
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                           | 08/17 | 09/17 | 10/17 | ... | 01/18 | 02/18 | 03/18 | ... | 08/18 |
+            | Provider Earned Total          | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from SFA       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Provider Paid by SFA           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | Levy account debited           | 0     | 500   | 500   | ... | 500   | 500   | 0     | ... | 0     |
+            | SFA Levy employer budget       | 500   | 500   | 500   | ... | 500   | 0     | 0     | ... | 0     |
+            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
+            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     | 0     | ... | 0     |
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                           | 02/18 | 03/18 | 04/18 | ... | 07/18 | 08/18 |
-            | Provider Earned Total          | 600   | 600   | 600   | ... | 600   | 0     |
-            | Provider Earned from SFA       | 0     | 0     | 0     | ... | 0     | 0     |
-            | Provider Earned from Employer  | 0     | 0     | 0     | ... | 0     | 0     |
-            | Provider Paid by SFA           | 0     | 0     | 0     | ... | 0     | 0     |
-            | Payment due from Employer      | 0     | 0     | 0     | ... | 0     | 0     |
-            | Levy account debited           | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA Levy employer budget       | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA Levy co-funding budget     | 0     | 0     | 0     | ... | 0     | 0     |
-            | SFA non-Levy co-funding budget | 0     | 0     | 0     | ... | 0     | 0     |
+            | Type                           | 08/17 | ... | 02/18 | 03/18 | 04/18 | ... | 07/18 | 08/18 |
+            | Provider Earned Total          | 0     | ... | 600   | 600   | 600   | ... | 600   | 0     |
+            | Provider Earned from SFA       | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | Provider Earned from Employer  | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | Provider Paid by SFA           | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | Payment due from Employer      | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | Levy account debited           | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | SFA Levy employer budget       | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | SFA Levy co-funding budget     | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
+            | SFA non-Levy co-funding budget | 0     | ... | 0     | 0     | 0     | ... | 0     | 0     |
 
 @_Minimum_Acceptance_
 Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentive payment in the transfer month - and the date at which the incentive is earned is before the transfer date 
@@ -179,24 +179,24 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       | 14/11/2017      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |                         |                                        |                           |                                          |
             | provider b | 16-18 programme only DAS | learner a | 15/11/2017 | 08/08/2018       |                 | continuing        |                      |                                     |                        |                                       | 4000                    | 15/11/2017                             | 1625                      | 15/11/2017                               |       
       
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+#        Then the data lock status will be as follows:
+#            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               |
+#            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+#            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
+#            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |
         
-       And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
-            | Provider Earned Total               | 500   | 500   | 500   | 1000  | 0     |
-            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     |
-            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  |
-            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 500   | 500   | 500   | 0     |
-            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     |
+       Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 |
+            | Provider Earned Total               | 500   | 500   | 500   | 1000  | 0     | 0     |
+            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     | 0     |
+            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  | 0     |
+            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited                | 0     | 500   | 500   | 500   | 0     | 0     |
+            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     | 0     |
+            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     | 0     |
         And the transaction types for the payments for provider a are:
             | Payment type             | 09/17 | 10/17 | 11/17 | 12/17 |
             | On-program               | 500   | 500   | 500   | 0     |
@@ -205,17 +205,17 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | Employer 16-18 incentive | 0     | 0     | 0     | 500   |
             | Provider 16-18 incentive | 0     | 0     | 0     | 500   |
        And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                                | 11/17 | 12/17 | 01/18 |
-            | Provider Earned Total               | 500   | 500   | 500   |
-            | Provider Earned from SFA            | 500   | 500   | 500   |
-            | Provider Earned from Employer       | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 500   | 500   |
-            | Payment due from Employer           | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 500   | 500   |
-            | SFA Levy employer budget            | 500   | 500   | 500   |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     |
+            | Type                                | 08/17 | ... | 11/17 | 12/17 | 01/18 |
+            | Provider Earned Total               | 0     | ... | 500   | 500   | 500   |
+            | Provider Earned from SFA            | 0     | ... | 500   | 500   | 500   |
+            | Provider Earned from Employer       | 0     | ... | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | ... | 0     | 500   | 500   |
+            | Payment due from Employer           | 0     | ... | 0     | 0     | 0     |
+            | Levy account debited                | 0     | ... | 0     | 500   | 500   |
+            | SFA Levy employer budget            | 0     | ... | 500   | 500   | 500   |
+            | SFA Levy co-funding budget          | 0     | ... | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | ... | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | ... | 0     | 0     | 0     |
         And the transaction types for the payments for provider b are:
             | Payment type             | 11/17 | 12/17 | 01/18 |
             | On-program               | 0     | 500   | 500   |
@@ -240,24 +240,24 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       | 14/12/2017      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |                         |                                        |                           |                                          |
             | provider b | 16-18 programme only DAS | learner a | 15/12/2017 | 08/09/2018       |                 | continuing        |                      |                                     |                        |                                       | 4000                    | 15/12/2017                             | 1625                      | 15/12/2017                               |        
       
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               | 02/18               |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |                     |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |                     |
+        #Then the data lock status will be as follows:
+        #    | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17               | 01/18               | 02/18               |
+        #    | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     | commitment 2 v1-001 | commitment 2 v1-001 | commitment 2 v1-001 |
+        #    | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |                     |
+        #    | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |                     |                     |                     |
         
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
-            | Provider Earned Total               | 500   | 500   | 500   | 1500  | 0     |
-            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     |
-            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  |
-            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 500   | 500   | 500   | 0     |
-            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     |
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 |
+            | Provider Earned Total               | 500   | 500   | 500   | 1500  | 0     | 0     | 0     |
+            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     | 0     | 0     |
+            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  | 0     | 0     |
+            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited                | 0     | 500   | 500   | 500   | 0     | 0     | 0     |
+            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     | 0     | 0     |
+            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     | 0     | 0     |
             
          And the transaction types for the payments for provider a are:
             | Payment type             | 09/17 | 10/17 | 11/17 | 12/17 |
@@ -268,17 +268,17 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | Provider 16-18 incentive | 0     | 0     | 0     | 500   |
             
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                                | 11/17 | 12/17 | 01/18 | 02/18 |
-            | Provider Earned Total               | 0     | 500   | 500   | 500   |
-            | Provider Earned from SFA            | 0     | 500   | 500   | 500   |
-            | Provider Earned from Employer       | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 0     | 500   | 500   |
-            | Payment due from Employer           | 0     | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 0     | 500   | 500   |
-            | SFA Levy employer budget            | 0     | 500   | 500   | 500   |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     | 0     |
+            | Type                                | 08/17 | ... | 11/17 | 12/17 | 01/18 | 02/18 |
+            | Provider Earned Total               | 0     | ... | 0     | 500   | 500   | 500   |
+            | Provider Earned from SFA            | 0     | ... | 0     | 500   | 500   | 500   |
+            | Provider Earned from Employer       | 0     | ... | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | ... | 0     | 0     | 500   | 500   |
+            | Payment due from Employer           | 0     | ... | 0     | 0     | 0     | 0     |
+            | Levy account debited                | 0     | ... | 0     | 0     | 500   | 500   |
+            | SFA Levy employer budget            | 0     | ... | 0     | 500   | 500   | 500   |
+            | SFA Levy co-funding budget          | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | ... | 0     | 0     | 0     | 0     |
             
          And the transaction types for the payments for provider b are:
             | Payment type             | 11/17 | 12/17 | 01/18 | 02/18 |
@@ -304,24 +304,24 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | provider a | 16-18 programme only DAS | learner a | 06/08/2017 | 08/08/2018       | 09/11/2017      | withdrawn         | 6000                 | 06/08/2017                          | 1500                   | 06/08/2017                            |                         |                                        |                           |                                          |
             | provider b | 16-18 programme only DAS | learner a | 10/11/2017 | 08/08/2018       |                 | continuing        |                      |                                     |                        |                                       | 4000                    | 10/11/2017                             | 1625                      | 10/11/2017                               |        
       
-        Then the data lock status will be as follows:
-            | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17 | 01/18 | 02/18 |
-            | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     |       |       |       |
-            | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |       |
-            | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |       |
+        #Then the data lock status will be as follows:
+        #    | Payment type             | 08/17               | 09/17               | 10/17               | 11/17               | 12/17 | 01/18 | 02/18 |
+        #    | On-program               | commitment 1 v1-001 | commitment 1 v1-001 | commitment 1 v1-001 |                     |       |       |       |
+        #    | Employer 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |       |
+        #    | Provider 16-18 incentive |                     |                     |                     | commitment 1 v1-001 |       |       |       |
         
-        And OBSOLETE - the earnings and payments break down for provider a is as follows:
-            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 |
-            | Provider Earned Total               | 500   | 500   | 500   | 1000  | 0     |
-            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     |
-            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  |
-            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 500   | 500   | 500   | 0     |
-            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     |
+        Then OBSOLETE - the earnings and payments break down for provider a is as follows:
+            | Type                                | 08/17 | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 | 02/18 |
+            | Provider Earned Total               | 500   | 500   | 500   | 1000  | 0     | 0     | 0     |
+            | Provider Earned from SFA            | 500   | 500   | 500   | 1000  | 0     | 0     | 0     |
+            | Provider Earned from Employer       | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | 500   | 500   | 500   | 1000  | 0     | 0     |
+            | Payment due from Employer           | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | Levy account debited                | 0     | 500   | 500   | 500   | 0     | 0     | 0     |
+            | SFA Levy employer budget            | 500   | 500   | 500   | 0     | 0     | 0     | 0     |
+            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | 0     | 0     | 1000  | 0     | 0     | 0     |
             
          And the transaction types for the payments for provider a are:
             | Payment type             | 09/17 | 10/17 | 11/17 | 12/17 |
@@ -332,17 +332,17 @@ Scenario: 1 learner aged 16-18, levy available, changes provider, earns incentiv
             | Provider 16-18 incentive | 0     | 0     | 0     | 500   |
             
         And OBSOLETE - the earnings and payments break down for provider b is as follows:
-            | Type                                | 11/17 | 12/17 | 01/18 | 02/18 |
-            | Provider Earned Total               | 500   | 500   | 500   | 500   |
-            | Provider Earned from SFA            | 0     | 0     | 0     | 0     |
-            | Provider Earned from Employer       | 0     | 0     | 0     | 0     |
-            | Provider Paid by SFA                | 0     | 0     | 0     | 0     |
-            | Payment due from Employer           | 0     | 0     | 0     | 0     |
-            | Levy account debited                | 0     | 0     | 0     | 0     |
-            | SFA Levy employer budget            | 0     | 0     | 0     | 0     |
-            | SFA Levy co-funding budget          | 0     | 0     | 0     | 0     |
-            | SFA non-Levy co-funding budget      | 0     | 0     | 0     | 0     |
-            | SFA Levy additional payments budget | 0     | 0     | 0     | 0     |
+            | Type                                | 08/17 | ... | 11/17 | 12/17 | 01/18 | 02/18 |
+            | Provider Earned Total               | 0     | ... | 500   | 500   | 500   | 500   |
+            | Provider Earned from SFA            | 0     | ... | 0     | 0     | 0     | 0     |
+            | Provider Earned from Employer       | 0     | ... | 0     | 0     | 0     | 0     |
+            | Provider Paid by SFA                | 0     | ... | 0     | 0     | 0     | 0     |
+            | Payment due from Employer           | 0     | ... | 0     | 0     | 0     | 0     |
+            | Levy account debited                | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA Levy employer budget            | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA Levy co-funding budget          | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA non-Levy co-funding budget      | 0     | ... | 0     | 0     | 0     | 0     |
+            | SFA Levy additional payments budget | 0     | ... | 0     | 0     | 0     | 0     |
             
          And the transaction types for the payments for provider b are:
             | Payment type             | 11/17 | 12/17 | 01/18 | 02/18 |

--- a/src/AcceptanceTesting/Features/maths_and_english.feature
+++ b/src/AcceptanceTesting/Features/maths_and_english.feature
@@ -560,16 +560,16 @@ Scenario: DPP-678 B Payment for a DAS learner, funding agreed within band maximu
 #	The English or maths aim is submitted with the same start and planned end date
       
     Then OBSOLETE - the earnings and payments break down for provider A is as follows:
-		  | Type                                    | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   |
-		  | Provider Earned Total                   | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 0       |
-		  | Provider Paid by SFA                    | 0       | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 1039.25 |
-		  | Payment due from Employer               | 0       | 0       | 0       | 0       | 0       | 0       |
-		  | Levy account debited                    | 0       | 1000    | 1000    | 1000    | 1000    | 1000    |
-		  | SFA Levy employer budget                | 1000    | 1000    | 1000    | 1000    | 1000    | 0       |
-		  | SFA Levy co-funding budget              | 0       | 0       | 0       | 0       | 0       | 0       |
-		  | SFA non-Levy co-funding budget          | 0       | 0       | 0       | 0       | 0       | 0       |
-		  | SFA non-levy additional payments budget | 0       | 0       | 0       | 0       | 0       | 0       |
-		  | SFA levy additional payments budget     | 39.25   | 39.25   | 39.25   | 39.25   | 39.25   | 0       |
+		  | Type                                    | 08/17   | 09/17   | 10/17   | 11/17   | 12/17   | 01/18   | 02/18 | ... | 08/18 |
+		  | Provider Earned Total                   | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 0       | 0     | ... | 0     |
+		  | Provider Paid by SFA                    | 0       | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 1039.25 | 0     | ... | 0     |
+		  | Payment due from Employer               | 0       | 0       | 0       | 0       | 0       | 0       | 0     | ... | 0     |
+		  | Levy account debited                    | 0       | 1000    | 1000    | 1000    | 1000    | 1000    | 0     | ... | 0     |
+		  | SFA Levy employer budget                | 1000    | 1000    | 1000    | 1000    | 1000    | 0       | 0     | ... | 0     |
+		  | SFA Levy co-funding budget              | 0       | 0       | 0       | 0       | 0       | 0       | 0     | ... | 0     |
+		  | SFA non-Levy co-funding budget          | 0       | 0       | 0       | 0       | 0       | 0       | 0     | ... | 0     |
+		  | SFA non-levy additional payments budget | 0       | 0       | 0       | 0       | 0       | 0       | 0     | ... | 0     |
+		  | SFA levy additional payments budget     | 39.25   | 39.25   | 39.25   | 39.25   | 39.25   | 0       | 0     | ... | 0     |
 		  
     And the transaction types for the payments for provider A are:
 		  | Payment type                   | 09/17 | 10/17 | 11/17 | 12/17 | 01/18 |
@@ -581,16 +581,16 @@ Scenario: DPP-678 B Payment for a DAS learner, funding agreed within band maximu
 
 
     Then OBSOLETE - the earnings and payments break down for provider B is as follows:
-		  | Type                                    | 01/18   | 02/18   | 03/18   | ... | 07/18   | 08/18   |
-		  | Provider Earned Total                   | 1189.96 | 1189.96 | 1189.96 | ... | 1189.96 | 0       |
-		  | Provider Paid by SFA                    | 0       | 1189.96 | 1189.96 | ... | 1189.96 | 1189.96 |
-		  | Payment due from Employer               | 0       | 0       | 0       | ... | 0       | 0       |
-		  | Levy account debited                    | 0       | 1142.86 | 1142.86 | ... | 1142.86 | 1142.86 |
-		  | SFA Levy employer budget                | 1142.86 | 1142.86 | 1142.86 | ... | 1142.86 | 0       |
-		  | SFA Levy co-funding budget              | 0       | 0       | 0       | ... | 0       | 0       |
-		  | SFA non-Levy additional payments budget | 0       | 0       | 0       | ... | 0       | 0       |
-		  | SFA levy additional payments budget     | 47.10   | 47.10   | 47.10   | ... | 47.10   | 0       |
-		  
+		  | Type                                    | 08/17 | ... | 01/18   | 02/18   | 03/18   | ... | 07/18   | 08/18   |
+		  | Provider Earned Total                   | 0     | ... | 1189.96 | 1189.96 | 1189.96 | ... | 1189.96 | 0       |
+		  | Provider Paid by SFA                    | 0     | ... | 0       | 1189.96 | 1189.96 | ... | 1189.96 | 1189.96 |
+		  | Payment due from Employer               | 0     | ... | 0       | 0       | 0       | ... | 0       | 0       |
+		  | Levy account debited                    | 0     | ... | 0       | 1142.86 | 1142.86 | ... | 1142.86 | 1142.86 |
+		  | SFA Levy employer budget                | 0     | ... | 1142.86 | 1142.86 | 1142.86 | ... | 1142.86 | 0       |
+		  | SFA Levy co-funding budget              | 0     | ... | 0       | 0       | 0       | ... | 0       | 0       |
+		  | SFA non-Levy additional payments budget | 0     | ... | 0       | 0       | 0       | ... | 0       | 0       |
+		  | SFA levy additional payments budget     | 0     | ... | 47.10   | 47.10   | 47.10   | ... | 47.10   | 0       |
+		  										
     And the transaction types for the payments for provider B are:
 		  | Payment type                   | 02/18   | 03/18   | ... | 07/18   | 08/18   | 
 		  | On-program                     | 1142.86 | 1142.86 | ... | 1142.86 | 1142.86 | 

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Contexts/EarningsAndPaymentsContext.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Contexts/EarningsAndPaymentsContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels;
 
 namespace SFA.DAS.Payments.AcceptanceTests.Contexts
@@ -7,6 +8,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Contexts
     {
         public EarningsAndPaymentsContext()
         {
+            PeriodDates = new List<DateTime>();
+
             OverallEarningsAndPayments = new List<EarningsAndPaymentsBreakdown>();
             LearnerOverallEarningsAndPayments = new List<LearnerEarningsAndPaymentsBreakdown>();
 
@@ -23,6 +26,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.Contexts
             ProviderEarnedForFrameworkUpliftOnBalancing = new List<ProviderEarnedPeriodValue>();
             ProviderEarnedForLearningSupport = new List<ProviderEarnedPeriodValue>();
         }
+
+        public List<DateTime> PeriodDates { get; set; }
 
         public List<EarningsAndPaymentsBreakdown> OverallEarningsAndPayments { get; set; }
         public List<LearnerEarningsAndPaymentsBreakdown> LearnerOverallEarningsAndPayments { get; set; }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/PeriodNameHelper.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/PeriodNameHelper.cs
@@ -28,7 +28,6 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
                 case "R14": return new DateTime(yearStartDate.Year + 1, 9, 1);
                 default: return new DateTime(yearStartDate.Year, 8, 1);
             }
-
         }
 
         public static string GetPeriodFromStringDate(string periodDate)
@@ -54,7 +53,25 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
                 case "10/18": return "R14";
                 default: return null;
             }
+        }
 
+        public static DateTime? GetDateFromStringDate(string periodDate)
+        {
+            if (string.IsNullOrEmpty(periodDate))
+                return null;
+
+            var dateParts = periodDate.Split('/');
+            if (dateParts.Length != 2)
+                return null;
+            int year;
+            if (!int.TryParse($"20{dateParts[1]}", out year))
+                return null;
+            int month;
+            if (!int.TryParse(dateParts[0], out month))
+                return null;
+            const int day = 1;
+
+            return new DateTime(year, month, day);
         }
 
         public static string GetStringDateFromPeriod(string period)

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             
             foreach (var period in periods)
             {
-                Console.WriteLine(period);
+                Console.WriteLine($@"Period: [{period}] ======================");
 
                 SetEnvironmentToPeriod(period);
                 EmployerAccountManager.UpdateAccountBalancesForPeriod(employerAccounts, period);

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -34,8 +34,6 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             
             foreach (var period in periods)
             {
-                Console.WriteLine($@"Period: [{period}] ======================");
-
                 SetEnvironmentToPeriod(period);
                 EmployerAccountManager.UpdateAccountBalancesForPeriod(employerAccounts, period);
 
@@ -64,8 +62,6 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
 
                 SavedDataCollector.CaptureAccountsDataForScenario();
                 SavedDataCollector.CaptureCommitmentsDataForScenario();
-
-                results.ForEach(learnerResults => Console.WriteLine(learnerResults));
             }
 
             DataLockEventsDataCollector.CollectDataLockEventsForAllPeriods(results, lookupContext);

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -132,10 +132,6 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             if (lastAssertionPeriodDate.HasValue && lastAssertionPeriodDate < latestDate)
                 latestDate = lastAssertionPeriodDate.Value.AddMonths(1).AddDays(-1);
 
-            //hax: commitments needs month after as well, not sure why
-            latestDate = latestDate.Value.AddMonths(1);
-            //endhax
-
             var date = earliestDate;
             while (date <= latestDate)
             {

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -33,6 +33,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             
             foreach (var period in periods)
             {
+                Console.WriteLine(period);
+
                 SetEnvironmentToPeriod(period);
                 EmployerAccountManager.UpdateAccountBalancesForPeriod(employerAccounts, period);
 
@@ -61,6 +63,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
 
                 SavedDataCollector.CaptureAccountsDataForScenario();
                 SavedDataCollector.CaptureCommitmentsDataForScenario();
+
+                results.ForEach(learnerResults => Console.WriteLine(learnerResults));
             }
 
             DataLockEventsDataCollector.CollectDataLockEventsForAllPeriods(results, lookupContext);

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
         private const short FamCodeActDasValue = 1;
         private const short FamCodeActNonDasValue = 2;
 
-        internal static List<LearnerResults> SubmitMultipleIlrAndRunMonthEndAndCollateResults(SubmissionContext multipleSubmissionsContext, LookupContext lookupContext, List<EmployerAccountReferenceData> employerAccounts)
+        internal static List<LearnerResults> SubmitMultipleIlrAndRunMonthEndAndCollateResults(SubmissionContext multipleSubmissionsContext, LookupContext lookupContext, List<EmployerAccountReferenceData> employerAccounts, DateTime lastAssertionPeriodDate)
         {
             var results = new List<LearnerResults>();
             if (TestEnvironment.ValidateSpecsOnly)
@@ -30,9 +30,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             {
                 periods.AddRange(ExtractPeriods(submission.IlrLearnerDetails, submission.FirstSubmissionDate));
             }
-
-            periods = periods.Distinct().ToList();
-
+            
             foreach (var period in periods)
             {
                 SetEnvironmentToPeriod(period);
@@ -54,7 +52,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
                         submission.LearningSupportStatus);
                     submission.HaveSubmissionsBeenDone = true;
                 }
-
+                
                 RunMonthEnd(period);
 
                 EarningsCollector.CollectForPeriod(period, results, lookupContext);
@@ -80,7 +78,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             List<ContractTypeReferenceData> contractTypes,
             List<EmploymentStatusReferenceData> employmentStatus,
             List<LearningSupportReferenceData> learningSupportStatus,
-            string[] periodsToSubmitTo = null)
+            List<string> periodsToSubmitTo = null,
+            DateTime? lastAssertionPeriodDate = null)
         {
             var results = new List<LearnerResults>();
             if (TestEnvironment.ValidateSpecsOnly)
@@ -117,7 +116,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             return results;
         }
 
-        private static string[] ExtractPeriods(List<IlrLearnerReferenceData> ilrLearnerDetails, DateTime? firstSubmissionDate)
+        private static List<string> ExtractPeriods(List<IlrLearnerReferenceData> ilrLearnerDetails, DateTime? firstSubmissionDate)
         {
             var periods = new List<string>();
 
@@ -157,7 +156,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
                 maxExplicitSubmissionPeriod = maxExplicitSubmissionPeriod.Value.AddMonths(-1);
             }
 
-            return periods.ToArray();
+            return periods.Distinct().ToList();
         }
 
         private static ProviderSubmissionDetails[] GroupLearnersByProvider(List<IlrLearnerReferenceData> ilrLearnerDetails, LookupContext lookupContext)

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -130,10 +130,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             var latestActualDate = ilrLearnerDetails.Select(x => x.ActualEndDate).Max();
             var latestDate = latestActualDate.HasValue && latestActualDate > latestPlannedDate ? latestActualDate : latestPlannedDate;
             if (lastAssertionPeriodDate.HasValue && lastAssertionPeriodDate < latestDate)
-                latestDate = lastAssertionPeriodDate.Value;
+                latestDate = lastAssertionPeriodDate.Value.AddMonths(1).AddDays(-1);
 
             var date = earliestDate;
-            while (string.CompareOrdinal(date.ToString("yyyyMM"), latestDate.Value.ToString("yyyyMM")) <= 0)
+            while (date <= latestDate)
             {
                 if (firstSubmissionDate.HasValue && date < firstSubmissionDate.Value.AddDays(-firstSubmissionDate.Value.Day + 1))
                 {

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -30,6 +30,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             {
                 periods.AddRange(ExtractPeriods(submission.IlrLearnerDetails, submission.FirstSubmissionDate));
             }
+            periods = periods.Distinct().ToList();
             
             foreach (var period in periods)
             {
@@ -160,7 +161,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
                 maxExplicitSubmissionPeriod = maxExplicitSubmissionPeriod.Value.AddMonths(-1);
             }
 
-            return periods.Distinct().ToList();
+            return periods;
         }
 
         private static ProviderSubmissionDetails[] GroupLearnersByProvider(List<IlrLearnerReferenceData> ilrLearnerDetails, LookupContext lookupContext)

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ExecutionManagers/SubmissionManager.cs
@@ -132,6 +132,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.ExecutionManagers
             if (lastAssertionPeriodDate.HasValue && lastAssertionPeriodDate < latestDate)
                 latestDate = lastAssertionPeriodDate.Value.AddMonths(1).AddDays(-1);
 
+            //hax: commitments needs month after as well, not sure why
+            latestDate = latestDate.Value.AddMonths(1);
+            //endhax
+
             var date = earliestDate;
             while (date <= latestDate)
             {

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ReferenceDataModels/EarningsAndPaymentsBreakdown.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ReferenceDataModels/EarningsAndPaymentsBreakdown.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels
 {
@@ -6,6 +7,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels
     {
         public EarningsAndPaymentsBreakdown()
         {
+            PeriodDates = new List<DateTime>();
             ProviderEarnedTotal = new List<PeriodValue>();
             ProviderEarnedFromSfa = new List<PeriodValue>();
             ProviderEarnedFromEmployers = new List<EmployerAccountPeriodValue>();
@@ -23,6 +25,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels
             RefundDueToEmployer = new List<EmployerAccountPeriodValue>();
         }
 
+        public List<DateTime> PeriodDates { get; set; }
         public string ProviderId { get; set; }
         public List<PeriodValue> ProviderEarnedTotal { get; set; }
         public List<PeriodValue> ProviderEarnedFromSfa { get; set; }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
@@ -24,12 +25,14 @@ namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
         {
             var stringBuilder = new StringBuilder();
 
-            stringBuilder.AppendLine(ProviderId);
-            stringBuilder.AppendLine(LearnerReferenceNumber);
-            Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: [{result.Value}][{result.CalculationPeriod}][{result.DeliveryPeriod}]"));
-            Payments.ForEach(result => stringBuilder.AppendLine($"Payment: [{result.Amount}][{result.CalculationPeriod}][{result.DeliveryPeriod}]"));//todo other fields
-            //todo other lists
-
+            stringBuilder.AppendLine($"Provider: [{ProviderId}], Learner Ref: [{LearnerReferenceNumber}]");
+            Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: value:[{result.Value}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
+            Payments.ForEach(result => stringBuilder.AppendLine($"Payment: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
+            LevyAccountBalanceResults.ForEach(result => stringBuilder.AppendLine($"Levy Account: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
+            if (DataLockEvents != null)
+                DataLockEvents.ToList().ForEach(result => stringBuilder.AppendLine($"Datalock Events: Id:[{result.Id}], has errors:[{result.HasErrors}], event source:[{result.EventSource}]"));
+            SubmissionDataLockResults.ForEach(result => stringBuilder.AppendLine($"Datalock Results: match period:[{result.MatchPeriod}], calc period:[{result.CalculationPeriod}], matches count:[{result.Matches.Count}]"));
+            
             return stringBuilder.ToString();
         }
     }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
@@ -26,14 +26,12 @@ namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
             var stringBuilder = new StringBuilder();
 
             stringBuilder.AppendLine($"Provider: [{ProviderId}], Learner Ref: [{LearnerReferenceNumber}]");
-            stringBuilder.AppendLine($"Earnings count: [{Earnings.Count}]");
-            //Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: value:[{result.Value}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
+            Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: value:[{result.Value}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             Payments.ForEach(result => stringBuilder.AppendLine($"Payment: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             LevyAccountBalanceResults.ForEach(result => stringBuilder.AppendLine($"Levy Account: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             if (DataLockEvents != null)
                 DataLockEvents.ToList().ForEach(result => stringBuilder.AppendLine($"Datalock Events: Id:[{result.Id}], has errors:[{result.HasErrors}], event source:[{result.EventSource}]"));
-            //SubmissionDataLockResults.ForEach(result => stringBuilder.AppendLine($"Datalock Results: match period:[{result.MatchPeriod}], calc period:[{result.CalculationPeriod}], matches count:[{result.Matches.Count}]"));
-            stringBuilder.AppendLine($"Submission Datalock results count: [{SubmissionDataLockResults.Count}]");
+            SubmissionDataLockResults.ForEach(result => stringBuilder.AppendLine($"Datalock Results: match period:[{result.MatchPeriod}], calc period:[{result.CalculationPeriod}], matches count:[{result.Matches.Count}]"));
             
             return stringBuilder.ToString();
         }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
@@ -26,12 +26,14 @@ namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
             var stringBuilder = new StringBuilder();
 
             stringBuilder.AppendLine($"Provider: [{ProviderId}], Learner Ref: [{LearnerReferenceNumber}]");
-            Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: value:[{result.Value}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
+            stringBuilder.AppendLine($"Earnings count: [{Earnings.Count}]");
+            //Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: value:[{result.Value}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             Payments.ForEach(result => stringBuilder.AppendLine($"Payment: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             LevyAccountBalanceResults.ForEach(result => stringBuilder.AppendLine($"Levy Account: amount:[{result.Amount}], calc period:[{result.CalculationPeriod}], delivery period:[{result.DeliveryPeriod}]"));
             if (DataLockEvents != null)
                 DataLockEvents.ToList().ForEach(result => stringBuilder.AppendLine($"Datalock Events: Id:[{result.Id}], has errors:[{result.HasErrors}], event source:[{result.EventSource}]"));
-            SubmissionDataLockResults.ForEach(result => stringBuilder.AppendLine($"Datalock Results: match period:[{result.MatchPeriod}], calc period:[{result.CalculationPeriod}], matches count:[{result.Matches.Count}]"));
+            //SubmissionDataLockResults.ForEach(result => stringBuilder.AppendLine($"Datalock Results: match period:[{result.MatchPeriod}], calc period:[{result.CalculationPeriod}], matches count:[{result.Matches.Count}]"));
+            stringBuilder.AppendLine($"Submission Datalock results count: [{SubmissionDataLockResults.Count}]");
             
             return stringBuilder.ToString();
         }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/ResultsDataModels/LearnerResults.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 
 namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
 {
@@ -18,5 +19,18 @@ namespace SFA.DAS.Payments.AcceptanceTests.ResultsDataModels
         public List<LevyAccountBalanceResult> LevyAccountBalanceResults { get; set; }
         public DataLockEventResult[] DataLockEvents { get; set; }
         public List<SubmissionDataLockPeriodResults> SubmissionDataLockResults { get; set; }
+
+        public override string ToString()
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendLine(ProviderId);
+            stringBuilder.AppendLine(LearnerReferenceNumber);
+            Earnings.ForEach(result => stringBuilder.AppendLine($"Earning: [{result.Value}][{result.CalculationPeriod}][{result.DeliveryPeriod}]"));
+            Payments.ForEach(result => stringBuilder.AppendLine($"Payment: [{result.Amount}][{result.CalculationPeriod}][{result.DeliveryPeriod}]"));//todo other fields
+            //todo other lists
+
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/DataLockSteps.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/DataLockSteps.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using SFA.DAS.Payments.AcceptanceTests.Assertions;
 using SFA.DAS.Payments.AcceptanceTests.Contexts;
 using SFA.DAS.Payments.AcceptanceTests.ExecutionManagers;
@@ -86,7 +87,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
             {
                 if (!submission.HaveSubmissionsBeenDone)
                 {
-                    var periodsToSubmitTo = new[]
+                    var periodsToSubmitTo = new List<string>
                     {
                         CommitmentsContext.Commitments.Max(x => x.EffectiveFrom).ToString("MM/yy")
                     };

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
@@ -58,6 +58,15 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
         [Then("OBSOLETE - the earnings and payments break down for provider (.*) is as follows:"), Obsolete]
         public void ThenProviderEarningAndPaymentsBreakDownToObsolete(string providerIdSuffix, Table earningAndPayments)
         {
+            var providerBreakdown = EarningsAndPaymentsContext.OverallEarningsAndPayments.SingleOrDefault(x => x.ProviderId == "provider " + providerIdSuffix);
+            if (providerBreakdown == null)
+            {
+                providerBreakdown = new EarningsAndPaymentsBreakdown { ProviderId = "provider " + providerIdSuffix };
+                EarningsAndPaymentsContext.OverallEarningsAndPayments.Add(providerBreakdown);
+            }
+
+            EarningAndPaymentTableParser.ParseEarningsAndPaymentsTableIntoContext(providerBreakdown, earningAndPayments);
+
             foreach (var submission in MultipleSubmissionsContext.Submissions)
             {
                 if (!submission.HaveSubmissionsBeenDone)
@@ -70,23 +79,12 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
                 }
             }
 
-            var providerBreakdown = EarningsAndPaymentsContext.OverallEarningsAndPayments.SingleOrDefault(x => x.ProviderId == "provider " + providerIdSuffix);
-            if (providerBreakdown == null)
-            {
-                providerBreakdown = new EarningsAndPaymentsBreakdown { ProviderId = "provider " + providerIdSuffix };
-                EarningsAndPaymentsContext.OverallEarningsAndPayments.Add(providerBreakdown);
-            }
-
-            EarningAndPaymentTableParser.ParseEarningsAndPaymentsTableIntoContext(providerBreakdown, earningAndPayments);
             AssertResults();
         }
 
         [Then("the earnings and payments break down for provider (.*) is as follows:")]
         public void ThenProviderEarningAndPaymentsBreakDownTo(string providerIdSuffix, Table earningAndPayments)
         {
-            PeriodContext.PeriodResults.AddRange(SubmissionManager.SubmitMultipleIlrAndRunMonthEndAndCollateResults(MultipleSubmissionsContext, LookupContext,
-                EmployerAccountContext.EmployerAccounts));
-
             var providerBreakdown = EarningsAndPaymentsContext.OverallEarningsAndPayments.SingleOrDefault(x => x.ProviderId == "provider " + providerIdSuffix);
             if (providerBreakdown == null)
             {
@@ -95,6 +93,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
             }
 
             EarningAndPaymentTableParser.ParseEarningsAndPaymentsTableIntoContext(providerBreakdown, earningAndPayments);
+
+            PeriodContext.PeriodResults.AddRange(SubmissionManager.SubmitMultipleIlrAndRunMonthEndAndCollateResults(MultipleSubmissionsContext, LookupContext,
+                EmployerAccountContext.EmployerAccounts));
+
             AssertResults();
         }
 

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
@@ -109,6 +109,8 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
         [Then("the transaction types for the payments for provider (.*) are:")]
         public void ThenTheTransactionTypesForNamedProviderEarningsAre(string providerIdSuffix, Table transactionTypes)
         {
+            TransactionTypeTableParser.ParseTransactionTypeTableIntoContext(EarningsAndPaymentsContext, $"provider {providerIdSuffix}", transactionTypes);
+
             foreach (var submission in MultipleSubmissionsContext.Submissions)
             {
                 if (!submission.HaveSubmissionsBeenDone)
@@ -116,12 +118,11 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
                     PeriodContext.PeriodResults.AddRange(SubmissionManager.SubmitIlrAndRunMonthEndAndCollateResults(
                         submission.IlrLearnerDetails, submission.FirstSubmissionDate,
                         LookupContext, EmployerAccountContext.EmployerAccounts, submission.ContractTypes,
-                        submission.EmploymentStatus, submission.LearningSupportStatus));
+                        submission.EmploymentStatus, submission.LearningSupportStatus, lastAssertionPeriodDate: EarningsAndPaymentsContext.PeriodDates.Max()));
                     submission.HaveSubmissionsBeenDone = true;
                 }
             }
 
-            TransactionTypeTableParser.ParseTransactionTypeTableIntoContext(EarningsAndPaymentsContext, $"provider {providerIdSuffix}", transactionTypes);
             AssertResults();
         }
 

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/StepDefinitions/EarningAndPaymentSteps.cs
@@ -74,7 +74,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
                     PeriodContext.PeriodResults.AddRange(SubmissionManager.SubmitIlrAndRunMonthEndAndCollateResults(
                         submission.IlrLearnerDetails, submission.FirstSubmissionDate,
                         LookupContext, EmployerAccountContext.EmployerAccounts, submission.ContractTypes,
-                        submission.EmploymentStatus, submission.LearningSupportStatus));
+                        submission.EmploymentStatus, submission.LearningSupportStatus, lastAssertionPeriodDate: providerBreakdown.PeriodDates.Max()));
                     submission.HaveSubmissionsBeenDone = true;
                 }
             }
@@ -95,7 +95,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.StepDefinitions
             EarningAndPaymentTableParser.ParseEarningsAndPaymentsTableIntoContext(providerBreakdown, earningAndPayments);
 
             PeriodContext.PeriodResults.AddRange(SubmissionManager.SubmitMultipleIlrAndRunMonthEndAndCollateResults(MultipleSubmissionsContext, LookupContext,
-                EmployerAccountContext.EmployerAccounts));
+                EmployerAccountContext.EmployerAccounts, providerBreakdown.PeriodDates.Max()));
 
             AssertResults();
         }

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using SFA.DAS.Payments.AcceptanceTests.ExecutionManagers;
 using SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels;
 using TechTalk.SpecFlow;
 
@@ -48,6 +49,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.TableParsers
         }
         private static void ParseEarningAndPaymentsRows(EarningsAndPaymentsBreakdown breakdown, Table earningAndPayments, string[] periodNames)
         {
+            breakdown.PeriodDates = periodNames
+                .Select(name => PeriodNameHelper.GetDateFromStringDate(name).GetValueOrDefault())
+                .ToList();
+
             foreach (var row in earningAndPayments.Rows)
             {
                 Match match;

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
@@ -50,6 +50,7 @@ namespace SFA.DAS.Payments.AcceptanceTests.TableParsers
         private static void ParseEarningAndPaymentsRows(EarningsAndPaymentsBreakdown breakdown, Table earningAndPayments, string[] periodNames)
         {
             breakdown.PeriodDates = periodNames
+                .Skip(1)
                 .Select(name => PeriodNameHelper.GetDateFromStringDate(name).GetValueOrDefault())
                 .ToList();
 

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/TransactionTypeTableParser.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/TransactionTypeTableParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using SFA.DAS.Payments.AcceptanceTests.Contexts;
+using SFA.DAS.Payments.AcceptanceTests.ExecutionManagers;
 using SFA.DAS.Payments.AcceptanceTests.ReferenceDataModels;
 using TechTalk.SpecFlow;
 
@@ -50,6 +51,11 @@ namespace SFA.DAS.Payments.AcceptanceTests.TableParsers
 
         private static void ParseTransationTypesRows(EarningsAndPaymentsContext context, string providerId, Table transactionTypesTable, string[] periodNames)
         {
+            context.PeriodDates = periodNames
+                .Skip(1)
+                .Select(name => PeriodNameHelper.GetDateFromStringDate(name).GetValueOrDefault())
+                .ToList();
+
             foreach (var row in transactionTypesTable.Rows)
             {
                 Match match;


### PR DESCRIPTION
The main change is to limit the month end processing to only those months that the scenario is asserting on. The feature files also needed to be updated for one of 2 reasons:

1. the assertions are split into 2 tables (e.g. for different providers), so the first table needs to cover all periods that the second table uses as well.
1. the scenario asserts data lock events and for some reason the commitment data locks were failing. Andy agreed to just comment these.