### PR TITLE
DPP-1307 rule to filter payments to assert

### DIFF
--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Features/transfers.feature
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Features/transfers.feature
@@ -1,12 +1,12 @@
 ﻿Feature: transfers
 
 Scenario: testing new rule in earnings and payments break down
-    Given levy balance > agreed price for all months
+    Given the employer 1 has a levy balance > agreed price for all months
     And the apprenticeship funding band maximum is 9000
 
 	And the following commitments exist:
-		| commitment Id | version Id | ULN       | start date | end date   | framework code | programme type | pathway code | agreed price | status    | effective from | effective to |
-		| 1             | 1          | learner a | 01/08/2017 | 01/08/2018 | 403            | 2              | 1            | 9000         | Active    | 01/08/2017     |              |
+		| commitment Id | version Id | ULN       | start date | end date   | framework code | programme type | pathway code | agreed price | status | effective from | effective to | employer   |
+		| 1             | 1          | learner a | 01/08/2017 | 01/08/2018 | 403            | 2              | 1            | 9000         | Active | 01/08/2017     |              | employer 1 |
         
     When an ILR file is submitted for period R01 with the following data:
 		| ULN       | learner type       | agreed price | start date | planned end date | actual end date | completion status | aim type         | aim sequence number | aim rate | framework code | programme type | pathway code | contract type | contract type date from | contract type date to | Employer Employment Status | Employer Employment Status Applies | Employer   | Employer Id |
@@ -27,11 +27,10 @@ Scenario: testing new rule in earnings and payments break down
         | Refund taken by SFA                     | 0      | 0      | 0      | -1278.50 |
         | Payment due from Employer               | 0      | 0      | 0      | 180      |
         | Refund due to employer                  | 0      | 0      | 0      | 0        |
-        | Levy account debited                    | 0      | 600    | 600    | 0        |
-        | employer 0 Levy account credited        | 0      | 0      | 0      | 1200     |
+        | employer 1 Levy account debited         | 0      | 600    | 600    | 0        |
+        | employer 1 Levy account credited        | 0      | 0      | 0      | 1200     |
         | SFA Levy employer budget                | 0      | 0      | 0      | 0        |
         | SFA Levy co-funding budget              | 0      | 0      | 0      | 0        |
         | SFA Levy additional payments budget     | 0      | 0      | 0      | 0        |
         | SFA non-Levy co-funding budget          | 540    | 540    | 540    | 540      |
         | SFA non-Levy additional payments budget | 39.25  | 39.25  | 39.25  | 39.25    |
-

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Features/transfers.feature
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/Features/transfers.feature
@@ -1,0 +1,37 @@
+﻿Feature: transfers
+
+Scenario: testing new rule in earnings and payments break down
+    Given levy balance > agreed price for all months
+    And the apprenticeship funding band maximum is 9000
+
+	And the following commitments exist:
+		| commitment Id | version Id | ULN       | start date | end date   | framework code | programme type | pathway code | agreed price | status    | effective from | effective to |
+		| 1             | 1          | learner a | 01/08/2017 | 01/08/2018 | 403            | 2              | 1            | 9000         | Active    | 01/08/2017     |              |
+        
+    When an ILR file is submitted for period R01 with the following data:
+		| ULN       | learner type       | agreed price | start date | planned end date | actual end date | completion status | aim type         | aim sequence number | aim rate | framework code | programme type | pathway code | contract type | contract type date from | contract type date to | Employer Employment Status | Employer Employment Status Applies | Employer   | Employer Id |
+		| learner a | programme only DAS | 9000         | 06/08/2017 | 20/08/2018       |                 | continuing        | programme        | 2                   |          | 403            | 2              | 1            | DAS           | 06/08/2017              | 20/08/2018            | in paid employment         | 05/08/2017                         | employer 1 | 12345678    |
+		| learner a | programme only DAS |              | 06/08/2017 | 20/08/2018       |                 | continuing        | maths or english | 1                   | 471      | 403            | 2              | 1            |               |                         |                       |                            |                                    |            |             |
+
+    And an ILR file is submitted for period R03 with the following data:
+        | ULN       | learner type           | agreed price | start date | planned end date | actual end date | completion status | aim type         | aim sequence number | aim rate | framework code | programme type | pathway code | contract type | contract type date from | contract type date to | Employer Employment Status | Employer Employment Status Applies | Employer   | Employer Id |
+        | learner a | programme only non-DAS | 9000         | 06/08/2017 | 20/08/2018       |                 | continuing        | programme        | 2                   |          | 403            | 2              | 1            | Non-DAS       | 06/08/2017              | 20/08/2018            | in paid employment         | 05/08/2017                         | employer 1 | 12345678    |
+        | learner a | programme only non-DAS |              | 06/08/2017 | 20/08/2018       |                 | continuing        | maths or english | 1                   | 471      | 403            | 2              | 1            |               |                         |                       |                            |                                    |            |             |
+  
+    Then the provider earnings and payments break down as follows:
+        | Type                                    | 08/17  | 09/17  | 10/17  | 11/17    |
+        | Provider Earned Total                   | 639.25 | 639.25 | 639.25 | 639.25   |
+        | Provider Earned from SFA                | 579.25 | 579.25 | 579.25 | 579.25   |
+        | Provider Earned from Employer           | 60     | 60     | 0      | 0        |
+        | Provider Paid by SFA                    | 0      | 639.25 | 639.25 | 1737.75  |
+        | Refund taken by SFA                     | 0      | 0      | 0      | -1278.50 |
+        | Payment due from Employer               | 0      | 0      | 0      | 180      |
+        | Refund due to employer                  | 0      | 0      | 0      | 0        |
+        | Levy account debited                    | 0      | 600    | 600    | 0        |
+        | employer 0 Levy account credited        | 0      | 0      | 0      | 1200     |
+        | SFA Levy employer budget                | 0      | 0      | 0      | 0        |
+        | SFA Levy co-funding budget              | 0      | 0      | 0      | 0        |
+        | SFA Levy additional payments budget     | 0      | 0      | 0      | 0        |
+        | SFA non-Levy co-funding budget          | 540    | 540    | 540    | 540      |
+        | SFA non-Levy additional payments budget | 39.25  | 39.25  | 39.25  | 39.25    |
+

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/SFA.DAS.Payments.AcceptanceTests.csproj
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/SFA.DAS.Payments.AcceptanceTests.csproj
@@ -266,6 +266,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>learner_changes_contract_type.feature</DependentUpon>
     </Compile>
+    <Compile Include="Features\transfers.feature.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>transfers.feature</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -532,6 +537,10 @@
       <Generator>SpecFlowSingleFileGenerator</Generator>
       <LastGenOutput>learner_changes_contract_type.feature.cs</LastGenOutput>
     </None>
+    <None Include="Features\transfers.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>transfers.feature.cs</LastGenOutput>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -599,7 +608,7 @@
   </ItemGroup>
   <Target Name="AfterUpdateFeatureFilesInProject">
       -->
-	  <!--<Move SourceFiles="@(SpecFlowGeneratedFiles)" DestinationFolder="Features" OverwriteReadOnlyFiles="true" />-->
+  <!--<Move SourceFiles="@(SpecFlowGeneratedFiles)" DestinationFolder="Features" OverwriteReadOnlyFiles="true" />-->
   <!-- include any files that specflow generated into the compilation of the project -->
   <!--
       <ItemGroup>

--- a/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
+++ b/src/AcceptanceTesting/SpecByExample/SFA.DAS.Payments.AcceptanceTests/TableParsers/EarningAndPaymentTableParser.cs
@@ -87,6 +87,10 @@ namespace SFA.DAS.Payments.AcceptanceTests.TableParsers
                 {
                     ParseEmployerRow(match.Groups[1].Value, row, periodNames, breakdown.EmployersLevyAccountDebited);
                 }
+                else if ((match = Regex.Match(row[0], "employer ([0-9]{1,}) Levy account credited", RegexOptions.IgnoreCase)).Success)
+                {
+                    ParseEmployerRow(match.Groups[1].Value, row, periodNames, breakdown.EmployersLevyAccountCredited);
+                }
                 else if (row[0].Equals("SFA Levy employer budget", StringComparison.InvariantCultureIgnoreCase))
                 {
                     ParseNonEmployerRow(row, periodNames, breakdown.SfaLevyBudget);


### PR DESCRIPTION
I've included a specflow feature that can be used to run the new `employer 1 Levy account credited` rule in the `EarningAndPaymentTableParser.cs`